### PR TITLE
fix(api): bounded retry on transient provider empty-response (#161)

### DIFF
--- a/utils/capture/multi_model_capture.py
+++ b/utils/capture/multi_model_capture.py
@@ -346,6 +346,36 @@ def _resolve_effective_callsite_kwargs(task_id, provider, kwargs, attempt=0):
     return effective
 
 
+def _fire_primary_with_retry(primary_fn, messages, kwargs, task_id,
+                             max_attempts=3, base_delay=0.6):
+    """Fire the primary provider call, retrying only on transient empty responses.
+
+    A provider occasionally returns a response with no text content
+    (finish_reason=stop, empty/whitespace content) -- a transient glitch that
+    succeeds on retry. Retrying HERE (the shared production boundary) keeps
+    create_completion() a thin router (wrapper-scope rule) while making every
+    registered callsite resilient. Any other error propagates immediately, and
+    an exhausted budget re-raises the original ProviderEmptyResponse unchanged.
+    """
+    from core.ai.api_client import ProviderEmptyResponse
+    last_exc = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return primary_fn(messages=messages, **kwargs)
+        except ProviderEmptyResponse as exc:
+            last_exc = exc
+            if attempt >= max_attempts:
+                break
+            _get_error_logger().warning(
+                "Transient empty provider response for %s (attempt %d/%d, "
+                "finish_reason=%s); retrying.",
+                task_id, attempt, max_attempts,
+                getattr(exc, "finish_reason", "unknown"),
+            )
+            time.sleep(base_delay * attempt)
+    raise last_exc
+
+
 def capture_and_fanout(task_id, primary_fn, messages, **kwargs):
     """Drop-in wrapper around client.chat.completions.create.
 
@@ -408,7 +438,7 @@ def capture_and_fanout(task_id, primary_fn, messages, **kwargs):
     # still player-visible production accounting and must happen before this
     # capture-specific early return.
     if request_provider == "lmstudio":
-        response = primary_fn(messages=messages, **kwargs)
+        response = _fire_primary_with_retry(primary_fn, messages, kwargs, task_id)
         _track_module_primary(
             response, task_id, request_provider, requested_model
         )
@@ -416,7 +446,7 @@ def capture_and_fanout(task_id, primary_fn, messages, **kwargs):
 
     # Always fire primary call synchronously
     start = time.time()
-    response = primary_fn(messages=messages, **kwargs)
+    response = _fire_primary_with_retry(primary_fn, messages, kwargs, task_id)
     primary_latency = round(time.time() - start, 3)
 
     # Account before either capture-disabled return below. Diagnostic capture


### PR DESCRIPTION
Closes #161.

## Problem
A provider occasionally returns a response with no text content (`finish_reason=stop`, empty/whitespace `content`) — a transient glitch that succeeds on retry. It was propagating uncaught as `ProviderEmptyResponse` and could terminate a game session. Observed ending a live headless combat acceptance run; **pre-existing and unrelated to the T040 referee swap** (seen before that change too).

## Fix
Add `_fire_primary_with_retry()` at the shared production boundary `utils/capture/multi_model_capture.py:capture_and_fanout()`, which wraps the primary `create_completion` call for every registered callsite:
- retries **only** `ProviderEmptyResponse` (up to 3 attempts, linear backoff),
- **re-raises unchanged** after the budget is exhausted (no silent swallow),
- lets **any other error propagate immediately** (no retry),
- both primary-call sites (lmstudio early return + main synchronous fire) route through it.

`create_completion()` stays a thin router — retry lives at the wrapper boundary, per the wrapper-scope rule. Zero added latency on the happy path (first call succeeds → single call, no sleep).

## Verification
Direct behavioral test of the helper:
- empty-once → succeeds on retry (2 calls) ✅
- always-empty → re-raises `ProviderEmptyResponse` after 3 attempts ✅
- non-empty error (e.g. `ValueError`) → propagates immediately, no retry ✅

Import smoke of `utils.capture.multi_model_capture` and `main` clean.

## Scope
Covers all 76 registered game callsites that route through `capture_and_fanout`. Direct `create_completion` callers that bypass the wrapper (ad-hoc/infra probes) are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)