### PR TITLE
NPC voice redesign: enriched say/do/want advisory voices fed to the DM (luna)

### DIFF
--- a/core/ai/action_handler.py
+++ b/core/ai/action_handler.py
@@ -906,12 +906,165 @@ def update_party_npcs(party_tracker_data, operation, npc):
                 npc_entry['name'] = npc_data['name']
                 debug(f"STATE_CHANGE: Using character file name '{npc_data['name']}' for party tracker", category="character_updates")
         
-        party_tracker_data["partyNPCs"].append(npc_entry)
+        # Idempotent add: skip if this NPC (by resolved display name) is already
+        # on the roster, so a duplicate add is a true no-op (T105 lifecycle relies
+        # on before/after roster equality to decide whether to fire).
+        _existing_names = {
+            str(x.get("name")) for x in party_tracker_data["partyNPCs"]
+        }
+        if npc_entry["name"] not in _existing_names:
+            party_tracker_data["partyNPCs"].append(npc_entry)
     elif operation == "remove":
         party_tracker_data["partyNPCs"] = [x for x in party_tracker_data["partyNPCs"] if x["name"] != npc["name"]]
 
     safe_json_dump(party_tracker_data, "party_tracker.json")
     info(f"STATE_CHANGE: Party NPCs updated - {operation} {npc['name']}", category="character_updates")
+
+
+def _apply_party_npc_lifecycle(
+    party_tracker_data,
+    operation,
+    npc_name,
+    npc_file,
+    lifecycle_context,
+    source_turn_id,
+):
+    """Best-effort post-commit lifecycle hook; never rolls back the roster."""
+    if getattr(config, "NPC_VOICE_ENABLED", False) is not True:
+        return False
+    try:
+        from core.npc.profile_service import seed_profile_best_effort
+        from core.npc.relationship_store import RelationshipStore, game_day_ordinal
+
+        context = lifecycle_context if isinstance(lifecycle_context, dict) else {}
+        module = str(party_tracker_data.get("module") or "")
+        world = party_tracker_data.get("worldConditions", {})
+        world = world if isinstance(world, dict) else {}
+        location_id = str(world.get("currentLocationId") or "")
+        game_day = game_day_ordinal(world)
+        player_names = party_tracker_data.get("partyMembers", [])
+        player_name = (
+            str(player_names[0]).strip()
+            if isinstance(player_names, list) and player_names
+            else ""
+        )
+        if not player_name or not npc_name or not npc_file:
+            raise ValueError("lifecycle hook is missing a committed identity path")
+        path_manager = ModulePathManager(module.replace(" ", "_"))
+        player_file = path_manager.get_character_path(player_name)
+        store = RelationshipStore()
+        if store.read_only:
+            raise RuntimeError(
+                "sidecar opened read-only: %s"
+                % (getattr(store, "read_only_reason", None) or "unknown")
+            )
+        starting_revision = store.snapshot()["revision"]
+        npc_id = store.ensure_identity(
+            kind="npc",
+            display_name=npc_name,
+            sheet_path=npc_file,
+            module=module,
+            location_id=location_id,
+            active=None,
+        )
+        player_id = store.ensure_identity(
+            kind="player",
+            display_name=player_name,
+            sheet_path=player_file,
+            module=module,
+            location_id=location_id,
+        )
+        store.get_relationship(npc_id, player_id, game_day=game_day)
+        if operation == "add":
+            store.migrate_legacy_identity(npc_id, player_id, game_day=game_day)
+            store.mark_joined(
+                npc_id,
+                player_id,
+                game_day=game_day,
+                module=module,
+                location_id=location_id,
+                source_turn_id=source_turn_id,
+                lifecycle_context=context,
+            )
+            sheet = safe_json_load(npc_file)
+            if not isinstance(sheet, dict):
+                raise ValueError("committed NPC sheet became unreadable")
+            lifecycle_events = (
+                store.snapshot().get("lifecycle", {}).get(npc_id, {}).get(
+                    "events", []
+                )
+            )
+            original_join = next(
+                (
+                    event
+                    for event in lifecycle_events
+                    if isinstance(event, dict) and event.get("kind") == "join"
+                ),
+                {},
+            )
+            lifecycle_source = {
+                "reason": original_join.get("cause", "unknown"),
+                "invitedBy": original_join.get("invitedBy", "unknown"),
+                "terms": original_join.get("terms", ""),
+                "personalObjective": original_join.get("personalObjective", ""),
+                "redLines": original_join.get("redLines", []),
+                "compensation": original_join.get("compensation", ""),
+                "expectedDuration": original_join.get(
+                    "expectedDuration", "unknown"
+                ),
+            }
+            seed_profile_best_effort(
+                store=store,
+                npc_id=npc_id,
+                npc_name=npc_name,
+                sheet=sheet,
+                lifecycle=lifecycle_source,
+            )
+        elif operation == "remove":
+            store.mark_departed(
+                npc_id,
+                module=module,
+                location_id=location_id,
+                cause=str(context.get("reason") or "unknown"),
+                departure_kind=str(context.get("departureKind") or "unknown"),
+                destination=str(context.get("destination") or "unknown"),
+                return_hook=str(context.get("returnHook") or ""),
+                unresolved_obligations=context.get("unresolvedObligations", []),
+                game_day=game_day,
+                source_turn_id=source_turn_id,
+            )
+        else:
+            raise ValueError("party NPC lifecycle operation is invalid")
+
+        final = store.snapshot()
+        edge_key = "%s|%s" % (npc_id, player_id)
+        identity = final["identities"].get(npc_id, {})
+        events = final["lifecycle"].get(npc_id, {}).get("events", [])
+        if operation == "add":
+            complete = (
+                identity.get("active") is True
+                and edge_key in final["relationships"]
+                and npc_id in final["profiles"]
+                and bool(events)
+                and events[-1].get("kind") in {"join", "rejoin"}
+            )
+        else:
+            complete = (
+                identity.get("active") is False
+                and bool(events)
+                and events[-1].get("kind") == "depart"
+            )
+        if not complete or final["revision"] <= starting_revision:
+            raise RuntimeError("sidecar lifecycle update did not commit completely")
+        return True
+    except Exception as exc:
+        warning(
+            "T105 NPC lifecycle sidecar update failed open: %s: %s"
+            % (type(exc).__name__, str(exc)),
+            category="character_updates",
+        )
+        return False
+
 
 def run_combat_simulation(encounter_id, party_tracker_data, location_data):
     """Run the combat simulation"""
@@ -2174,7 +2327,66 @@ Please use a valid location that exists in the current area ({current_area_id}) 
     elif action_type == ACTION_UPDATE_PARTY_NPCS:
         operation = parameters["operation"]
         npc = parameters["npc"]
+        # Capture the roster before the commit so we can tell whether this action
+        # actually changed state (idempotent duplicate add / no-op remove must not
+        # trigger a lifecycle hook or a conversation-history refresh).
+        _roster_before = [
+            dict(x) for x in party_tracker_data.get("partyNPCs", [])
+        ]
         update_party_npcs(party_tracker_data, operation, npc)
+        _roster_after = party_tracker_data.get("partyNPCs", [])
+        _state_changed = _roster_after != _roster_before
+        # T105: best-effort NPC-voice lifecycle hook after the roster commit.
+        # Only fires when the roster actually changed (idempotent duplicate add /
+        # no-op remove is a true no-op). Flag-gated + fail-open; must never break
+        # the committed roster action.
+        if _state_changed:
+            needs_conversation_history_update = True
+            try:
+                lifecycle_context = parameters.get("lifecycleContext")
+                source_turn_id = hashlib.sha256(
+                    json.dumps(
+                        {
+                            "action": action,
+                            "historyLength": len(conversation_history or []),
+                        },
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("ascii")
+                ).hexdigest()[:32]
+                npc_name = str(npc.get("name") or "")
+                npc_file = ""
+                try:
+                    _lc_module = party_tracker_data.get("module", "").replace(" ", "_")
+                    _lc_pm = ModulePathManager(_lc_module)
+                    from updates.update_character_info import (
+                        find_character_file_fuzzy,
+                        normalize_character_name,
+                    )
+                    _matched = find_character_file_fuzzy(npc_name)
+                    if _matched:
+                        npc_file = _lc_pm.get_character_path(_matched)
+                    else:
+                        npc_file = _lc_pm.get_character_path(
+                            normalize_character_name(npc_name)
+                        )
+                except Exception:
+                    npc_file = ""
+                _apply_party_npc_lifecycle(
+                    party_tracker_data,
+                    operation,
+                    npc_name,
+                    npc_file,
+                    lifecycle_context,
+                    source_turn_id,
+                )
+            except Exception as exc:
+                warning(
+                    "T105 NPC lifecycle hook raised after roster commit: %s: %s"
+                    % (type(exc).__name__, str(exc)),
+                    category="character_updates",
+                )
 
     elif action_type == ACTION_UPDATE_ENCOUNTER:
         debug("STATE_CHANGE: Processing updateEncounter action", category="combat_processing")

--- a/core/ai/combat_agent.py
+++ b/core/ai/combat_agent.py
@@ -11,6 +11,7 @@ Neither role writes game state.
 
 import json
 import time
+from collections.abc import Mapping
 
 from core.ai import api_client
 from core.ai.combat_capabilities import (
@@ -284,6 +285,13 @@ The player need not name mechanics. Do not invent an unavailable capability.
 For multi-step actions, preserve the player's goal, resolve only the steps that
 are currently possible, and request a roll or choice when required.
 
+npcVoiceIntents, when present, is private advisory characterization for only
+the exact actor IDs keyed in that object. It may suggest loyalty, protection,
+retreat, targets, or tactics, but it is never rules or action authority.
+requiredActorIds, encounter facts, sheets, capability candidates, and rule
+references remain authoritative. Ignore or legally reconcile impossible voice
+advice and always return a mechanically legal intent.
+
 Return one JSON object with stateVersion and intents. Return EXACTLY one intent
 for every actorId in requiredActorIds, in that exact order. Do not add or omit
 actors, even if an earlier action might defeat a later actor; code skips them.
@@ -380,6 +388,7 @@ def request_intent_batch(
     player_input,
     spell_references=None,
     correction=None,
+    npc_voice_intents=None,
 ):
     """Call T096 once for an ordered batch of decisions, with no mutations."""
     provider, call_config = _provider_config("intent")
@@ -404,6 +413,25 @@ def request_intent_batch(
             else spell_references or {}
         ),
     }
+    pending_ids = list(pending_turn.get("actorIds", []))
+    if isinstance(npc_voice_intents, Mapping):
+        bounded_voice = {}
+        for actor_id in pending_ids:
+            row = npc_voice_intents.get(actor_id)
+            if not isinstance(row, Mapping):
+                continue
+            npc_name = row.get("npcName")
+            thought = row.get("thought")
+            if not isinstance(npc_name, str) or not npc_name.strip():
+                continue
+            if not isinstance(thought, str) or not thought.strip():
+                continue
+            bounded_voice[actor_id] = {
+                "npcName": npc_name.strip()[:100],
+                "thought": thought.strip()[:640],
+            }
+        if bounded_voice:
+            payload["npcVoiceIntents"] = bounded_voice
     if contextual_payload:
         payload["ruleReferences"] = contextual_payload.get("ruleReferences", [])
         payload["spellActionIndex"] = contextual_payload.get("spellActionIndex", [])

--- a/core/ai/conversation_utils.py
+++ b/core/ai/conversation_utils.py
@@ -311,6 +311,218 @@ def load_json_data(file_path):
         print(f"{file_path} has an invalid JSON format. Returning None.")
         return None
 
+
+def filter_active_companion_memories(memory_rows, party_tracker_data):
+    """Keep transitional legacy memory only for exact active roster names."""
+    active_roster_names = {
+        str(row.get("name") or "").strip().casefold()
+        for row in (party_tracker_data or {}).get("partyNPCs", [])
+        if isinstance(row, dict) and str(row.get("name") or "").strip()
+    }
+    return [
+        row
+        for row in memory_rows
+        if isinstance(row, dict)
+        and str(row.get("n") or "").strip().casefold() in active_roster_names
+    ]
+
+
+_LEGACY_COMPANION_MEMORY_PREFIX = "=== COMPANION MEMORIES (Compressed) ==="
+_CANONICAL_COMPANION_CONTEXT_PREFIX = "=== ACTIVE COMPANION CANONICAL CONTEXT ==="
+_MAX_CANONICAL_COMPANION_CONTEXT_CHARS = 16000
+
+
+def _build_legacy_companion_memory_message(party_tracker_data, legacy_path):
+    """Return the Phase 6 active-roster legacy block without changing its bytes."""
+    try:
+        path = os.fspath(legacy_path)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as handle:
+            memories = json.load(handle)
+        if not memories or "npcs" not in memories:
+            return None
+
+        valid_npcs = []
+        for npc in filter_active_companion_memories(
+            memories["npcs"], party_tracker_data
+        ):
+            es = npc.get("es", [0.0, 0.0, 0.0, 0.0, 0.0])
+            mem = npc.get("mem", [])
+            interaction_count = npc.get("ti", 0)
+            npc_name = npc.get("n", "unknown")
+            if (
+                sum(abs(value) for value in es) == 0.0
+                and len(mem) == 0
+                and interaction_count > 0
+            ):
+                warning(
+                    f"Detected corrupted memory data for {npc_name}: "
+                    f"{interaction_count} interactions but zero emotional state and no memories. "
+                    "This NPC will be excluded from context until memories regenerate.",
+                    category="memory",
+                )
+                continue
+            valid_npcs.append(npc)
+
+        if not valid_npcs:
+            debug(
+                "No valid companion memories to inject (all NPCs have corrupted data)",
+                category="memory",
+            )
+            return None
+        memory_content = _LEGACY_COMPANION_MEMORY_PREFIX + "\n"
+        memory_content += json.dumps(valid_npcs, separators=(",", ":"))
+        memory_content += (
+            "\n@GUIDE: Use ES (emotional state) for tone, "
+            "BM (behavioral model) for consistency"
+        )
+        memory_content += "\n==="
+        return {"role": "system", "content": memory_content}
+    except Exception as exc:
+        warning(f"Failed to inject memories (non-fatal): {exc}", category="memory")
+        return None
+
+
+def _latest_player_input(conversation_history):
+    from core.npc.voice_context import _raw_player_text
+
+    for message in reversed(conversation_history):
+        if isinstance(message, dict) and message.get("role") == "user":
+            value = _raw_player_text(message.get("content"))
+            if value and not value.startswith("Error Note:"):
+                return value
+    return ""
+
+
+def _canonical_context_row(packet):
+    """Project one bounded packet without vectors or private working memory."""
+    npc = packet["npc"]
+    context = packet["context"]
+    evidence = []
+    for record in packet["relationship"].get("recentEvents", []):
+        evidence.append(
+            {
+                "actor": record.get("actor", ""),
+                "target": record.get("target", ""),
+                "eventType": record.get("eventType"),
+                "magnitude": record.get("magnitude"),
+                "witnessed": bool(record.get("witnessed")),
+                "summary": record.get("summary", ""),
+            }
+        )
+    return {
+        "npc": {
+            "id": npc["id"],
+            "name": npc["name"],
+            "role": npc["role"],
+        },
+        "profile": npc["profile"],
+        "relationshipEvidence": evidence,
+        "currentGoals": context.get("currentGoals", []),
+    }
+
+
+def _build_canonical_companion_context_message(
+    party_tracker_data,
+    conversation_history,
+    *,
+    relationship_store,
+    path_manager,
+    json_loader,
+):
+    from core.npc.voice_context import build_ooc_packets_for_turn
+
+    members = party_tracker_data.get("partyMembers", [])
+    first_member = members[0] if isinstance(members, list) and members else ""
+    player_name = (
+        str(first_member.get("name") or "").strip()
+        if isinstance(first_member, dict)
+        else str(first_member or "").strip()
+    )
+    if not player_name:
+        return None
+    packets = build_ooc_packets_for_turn(
+        party_tracker_data=party_tracker_data,
+        player_name=player_name,
+        raw_input=_latest_player_input(conversation_history),
+        location_data=None,
+        conversation_prefix=conversation_history,
+        path_manager=path_manager,
+        json_loader=json_loader,
+        relationship_store=relationship_store,
+        limit=4,
+    )
+    rows = []
+    for packet in packets:
+        candidate_rows = rows + [_canonical_context_row(packet)]
+        candidate_json = json.dumps(
+            candidate_rows,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+        candidate_content = (
+            _CANONICAL_COMPANION_CONTEXT_PREFIX
+            + "\n"
+            + candidate_json
+            + "\n==="
+        )
+        if len(candidate_content) > _MAX_CANONICAL_COMPANION_CONTEXT_CHARS:
+            break
+        rows = candidate_rows
+    if not rows:
+        return None
+    content = (
+        _CANONICAL_COMPANION_CONTEXT_PREFIX
+        + "\n"
+        + json.dumps(rows, ensure_ascii=True, separators=(",", ":"))
+        + "\n==="
+    )
+    return {"role": "system", "content": content}
+
+
+def build_companion_memory_message(
+    party_tracker_data,
+    conversation_history,
+    *,
+    npc_voice_enabled,
+    relationship_store=None,
+    path_manager=None,
+    json_loader=safe_json_load,
+    legacy_path=os.path.join(
+        "data", "companion_memories", "memories_compressed.json"
+    ),
+):
+    """Select canonical active context, or preserve the exact legacy fallback."""
+    if not npc_voice_enabled:
+        return _build_legacy_companion_memory_message(
+            party_tracker_data, legacy_path
+        )
+
+    try:
+        from core.npc.relationship_store import RelationshipStore
+
+        store = relationship_store or RelationshipStore()
+        if not store.path.exists() or store.read_only:
+            return _build_legacy_companion_memory_message(
+                party_tracker_data, legacy_path
+            )
+        module_name = str(party_tracker_data.get("module") or "").replace(" ", "_")
+        manager = path_manager or ModulePathManager(module_name)
+        return _build_canonical_companion_context_message(
+            party_tracker_data,
+            conversation_history,
+            relationship_store=store,
+            path_manager=manager,
+            json_loader=json_loader,
+        )
+    except Exception as exc:
+        warning(
+            f"Failed to inject canonical companion context (non-fatal): {exc}",
+            category="memory",
+        )
+        return None
+
 def update_conversation_history(conversation_history, party_tracker_data, plot_data, module_data):
     # Read the actual system prompt to get the proper identifier
     with open(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "prompts", "system_prompt.txt"), "r", encoding="utf-8") as file:
@@ -400,7 +612,13 @@ def update_conversation_history(conversation_history, party_tracker_data, plot_d
             continue
 
         # ALWAYS remove companion memories - fresh data will be injected from file
-        if msg["role"] == "system" and "=== COMPANION MEMORIES (Compressed) ===" in msg.get("content", ""):
+        if msg["role"] == "system" and any(
+            marker in msg.get("content", "")
+            for marker in (
+                _LEGACY_COMPANION_MEMORY_PREFIX,
+                _CANONICAL_COMPANION_CONTEXT_PREFIX,
+            )
+        ):
             debug("Removing existing companion memories (will be refreshed from file)", category="memory")
             continue
 
@@ -410,49 +628,26 @@ def update_conversation_history(conversation_history, party_tracker_data, plot_d
     # Create a new list starting with the primary system prompt
     new_history = [primary_system_prompt] if primary_system_prompt else []
 
-    # ALWAYS inject fresh compressed companion memories from file
-    # This prevents stale data from being perpetuated in conversation history
+    # Refresh exactly one companion context block immediately after the main prompt.
+    # T105: flag-off and unavailable-sidecar paths retain the Phase 6 legacy bytes.
     try:
-        compressed_path = os.path.join("data", "companion_memories", "memories_compressed.json")
-        if os.path.exists(compressed_path):
-            with open(compressed_path, 'r', encoding='utf-8') as f:
-                memories = json.load(f)
+        import config as runtime_config
 
-            # Format memories compactly for AI
-            if memories and 'npcs' in memories:
-                # Self-healing: Validate memory structure and fix corrupted data
-                valid_npcs = []
-                for npc in memories['npcs']:
-                    # Check for corrupted emotional state (all zeros) or empty memories with positive interaction count
-                    es = npc.get('es', [0.0, 0.0, 0.0, 0.0, 0.0])
-                    mem = npc.get('mem', [])
-                    interaction_count = npc.get('ti', 0)
-                    npc_name = npc.get('n', 'unknown')
-
-                    # Flag suspicious data patterns
-                    if sum(abs(x) for x in es) == 0.0 and len(mem) == 0 and interaction_count > 0:
-                        warning(f"Detected corrupted memory data for {npc_name}: " +
-                               f"{interaction_count} interactions but zero emotional state and no memories. " +
-                               "This NPC will be excluded from context until memories regenerate.",
-                               category="memory")
-                        continue
-
-                    valid_npcs.append(npc)
-
-                if valid_npcs:
-                    memory_content = "=== COMPANION MEMORIES (Compressed) ===\n"
-                    memory_content += json.dumps(valid_npcs, separators=(',', ':'))
-                    memory_content += "\n@GUIDE: Use ES (emotional state) for tone, BM (behavioral model) for consistency"
-                    memory_content += "\n==="
-
-                    # Insert right after system prompt
-                    memory_message = {'role': 'system', 'content': memory_content}
-                    new_history.append(memory_message)
-                    debug(f"Injected fresh companion memories for {len(valid_npcs)} NPCs", category="memory")
-                else:
-                    debug("No valid companion memories to inject (all NPCs have corrupted data)", category="memory")
-    except Exception as e:
-        warning(f"Failed to inject memories (non-fatal): {e}", category="memory")
+        memory_message = build_companion_memory_message(
+            party_tracker_data,
+            conversation_history,
+            npc_voice_enabled=(
+                getattr(runtime_config, "NPC_VOICE_ENABLED", False) is True
+            ),
+        )
+        if memory_message is not None:
+            new_history.append(memory_message)
+            if _CANONICAL_COMPANION_CONTEXT_PREFIX in memory_message["content"]:
+                debug("Injected selective canonical companion context", category="memory")
+            else:
+                debug("Injected fresh active-roster legacy companion memories", category="memory")
+    except Exception as exc:
+        warning(f"Failed to inject memories (non-fatal): {exc}", category="memory")
 
     debug(f"VALIDATION: Current module from party tracker: '{current_module}'", category="module_management")
     

--- a/core/headless/bootstrap.py
+++ b/core/headless/bootstrap.py
@@ -105,7 +105,20 @@ def prepare_game_dir(game_dir, repo_root, module=None):
         src = os.path.join(repo_root, name)
         dst = os.path.join(game_dir, name)
         if os.path.isdir(src) and not os.path.exists(dst):
-            shutil.copytree(src, dst)
+            ignore = None
+            if name == "data":
+                def ignore_private_runtime(directory, names):
+                    normalized = os.path.normpath(directory).replace("\\", "/")
+                    if normalized.endswith("/data/companion_memories"):
+                        return [
+                            value
+                            for value in names
+                            if value.endswith((".json", ".lock", ".tmp", ".bak"))
+                        ]
+                    return []
+
+                ignore = ignore_private_runtime
+            shutil.copytree(src, dst, ignore=ignore)
             copied.append(name)
     if module:
         dst = os.path.join(game_dir, "modules", module)

--- a/core/managers/campaign_manager.py
+++ b/core/managers/campaign_manager.py
@@ -94,6 +94,35 @@ from utils.enhanced_logger import debug, info, warning, error, game_event, set_s
 set_script_name(__name__)
 
 
+def _update_npc_module_lifecycle_best_effort(party_tracker, source_turn_id):
+    """Advance private active-NPC context after a committed party transition.
+
+    Best-effort and flag-gated: a failure never blocks the module transition.
+    Records the transition in the NPC voice relationship sidecar so departed /
+    rejoined companions and per-module lifecycle stay consistent for T105.
+    """
+    if getattr(config, "NPC_VOICE_ENABLED", False) is not True:
+        return
+    try:
+        from core.npc.relationship_store import RelationshipStore, game_day_ordinal
+
+        if not isinstance(party_tracker, dict):
+            return
+        world = party_tracker.get("worldConditions", {})
+        world = world if isinstance(world, dict) else {}
+        RelationshipStore().mark_module_transition(
+            module=str(party_tracker.get("module") or ""),
+            location_id=str(world.get("currentLocationId") or ""),
+            source_turn_id=str(source_turn_id or "")[:120],
+            game_day=game_day_ordinal(world),
+        )
+    except Exception as exc:
+        warning(
+            "NPC module lifecycle update failed open: %s" % type(exc).__name__,
+            category="module_loading",
+        )
+
+
 def _is_valid_campaign_export_data(exported_data: Any) -> bool:
     """Check the structural contract consumed by campaign-state importers."""
     if not isinstance(exported_data, dict):
@@ -1759,6 +1788,7 @@ class CampaignManager:
                 completion_id,
                 conversation_history=conversation_history,
             )
+            _update_npc_module_lifecycle_best_effort(updated, completion_id)
             return original, updated
 
     def publish_location_module_transition(
@@ -1857,6 +1887,7 @@ class CampaignManager:
                 completion_id,
                 conversation_history=conversation_history,
             )
+            _update_npc_module_lifecycle_best_effort(updated, completion_id)
             return transition_result, updated
 
     def _cancel_prepared_module_completion_intent(
@@ -2221,6 +2252,9 @@ class CampaignManager:
                     repaired_party = copy.deepcopy(persisted_party)
                     repaired_party["module"] = intent["to_module"]
                     safe_json_dump(repaired_party, "party_tracker.json")
+                    _update_npc_module_lifecycle_best_effort(
+                        repaired_party, intent.get("completion_id", "")
+                    )
                     persisted_module = intent["to_module"]
                 if persisted_module != intent["to_module"]:
                     next_intent = (

--- a/core/managers/combat_manager.py
+++ b/core/managers/combat_manager.py
@@ -898,7 +898,7 @@ def sanitize_unicode_for_logging(text):
     
     return text
 
-def validate_combat_response(response, encounter_data, user_input, conversation_history=None):
+def validate_combat_response(response, encounter_data, user_input, conversation_history=None, npc_voice_batch=None):
     """
     Validate a combat response for accuracy in HP tracking, combat flow, etc.
     Returns True if valid, or a string with the reason for failure if invalid.
@@ -996,9 +996,31 @@ def validate_combat_response(response, encounter_data, user_input, conversation_
         {"role": "user", "content": T040_VERDICT_REQUEST},
     ])
 
+    validation_messages_for_diagnostics = validation_conversation
+    if npc_voice_batch is not None:
+        try:
+            from core.npc.voice_context import (
+                inject_voice_context,
+                redact_voice_context,
+            )
+
+            validation_conversation = inject_voice_context(
+                validation_conversation,
+                npc_voice_batch,
+            )
+            validation_messages_for_diagnostics = redact_voice_context(
+                validation_conversation
+            )
+        except Exception as voice_error:
+            debug(
+                "T105 combat validator guidance skipped: %s"
+                % type(voice_error).__name__,
+                category="combat_validation",
+            )
+
     # Export validation conversation for review
     with open("validation_messages_to_api.json", "w", encoding="utf-8") as f:
-        json.dump(validation_conversation, f, indent=2, ensure_ascii=False)
+        json.dump(validation_messages_for_diagnostics, f, indent=2, ensure_ascii=False)
     
     # Calculate size for debugging
     validation_size = sum(len(json.dumps(msg)) for msg in validation_conversation)
@@ -1032,7 +1054,7 @@ def validate_combat_response(response, encounter_data, user_input, conversation_
             # Log API call to master log
             try:
                 from utils.api_logger import log_api_call
-                log_api_call("combat_validation", validation_conversation, validation_result,
+                log_api_call("combat_validation", validation_messages_for_diagnostics, validation_result,
                             metadata={"temperature": 0.3, "attempt": attempt+1})
             except Exception as e:
                 print(f"[API_LOG] Warning: Failed to log combat validation call: {e}")
@@ -4579,7 +4601,38 @@ Rules:
        # Add user input to conversation history
        conversation_history.append({"role": "user", "content": user_input_with_note})
        save_json_file(conversation_history_file, conversation_history)
-       
+
+       # Compose legacy NPC guidance once for this calculated initiative
+       # window. The batch is request-local and is reused for every T045/T040
+       # correction attempt below.
+       legacy_voice_batch = None
+       if getattr(config, "NPC_VOICE_ENABLED", False) is True:
+           try:
+               from core.npc.voice_context import run_legacy_combat_voice_stage
+
+               character_paths, context_sheets = _agentic_combat_context(
+                   encounter_data,
+                   path_manager,
+                   monster_templates,
+               )
+               legacy_voice_stage = run_legacy_combat_voice_stage(
+                   encounter_data=encounter_data,
+                   turn_window=turn_window_json,
+                   character_paths=character_paths,
+                   context_sheets=context_sheets,
+                   party_tracker_data=party_tracker_data,
+                   location_info=location_info,
+                   player_input=raw_combat_input_text,
+                   conversation_prefix=conversation_history,
+               )
+               legacy_voice_batch = legacy_voice_stage.batch
+           except Exception as exc:
+               debug(
+                   "T105 legacy combat stage skipped: %s"
+                   % type(exc).__name__,
+                   category="combat_events",
+               )
+
        # Get AI response with validation and retries
        max_retries = 5
        valid_response = False
@@ -4616,6 +4669,26 @@ Rules:
 
                # Compress conversation history before sending to AI
                messages_to_send = combat_message_compressor.process_combat_conversation(conversation_history)
+
+               # T105 guidance is private and request-local. Compression runs
+               # first, then the same immutable batch is inserted before the
+               # final user combat-state message on every correction attempt.
+               if legacy_voice_batch is not None:
+                   try:
+                       from core.npc.voice_context import (
+                           inject_legacy_combat_voice_context,
+                       )
+
+                       messages_to_send = inject_legacy_combat_voice_context(
+                           messages_to_send,
+                           legacy_voice_batch,
+                       )
+                   except Exception as voice_error:
+                       debug(
+                           "T105 legacy T045 guidance skipped: %s"
+                           % type(voice_error).__name__,
+                           category="combat_events",
+                       )
 
                response = capture_and_fanout("T045", api_client.create_completion,
                    _request_provider=MODEL_PROVIDER,
@@ -4723,7 +4796,13 @@ Rules:
                except Exception as e:
                    debug(f"Could not update status: {e}", category="status")
                
-               validation_result = validate_combat_response(ai_response, encounter_data, user_input_text, conversation_history)
+               validation_result = validate_combat_response(
+                   ai_response,
+                   encounter_data,
+                   user_input_text,
+                   conversation_history,
+                   npc_voice_batch=legacy_voice_batch,
+               )
                
                if validation_result is True:
                    valid_response = True
@@ -4824,7 +4903,27 @@ Rules:
            error("FAILURE: Failed to get a valid AI response after multiple attempts", category="combat_events")
            _display_combat_narration(T045_REJECTED_ACTION_NARRATION)
            continue
-       
+
+       # The T105 event describes only prior accepted evidence. Commit it once
+       # the current T045 candidate crosses T040, before legacy action
+       # processing begins. Store failures remain advisory and fail open.
+       if legacy_voice_batch is not None:
+           try:
+               from core.npc.voice_context import (
+                   commit_accepted_combat_voice_batch,
+               )
+
+               commit_accepted_combat_voice_batch(
+                   legacy_voice_batch,
+                   party_tracker_data,
+               )
+           except Exception as exc:
+               debug(
+                   "T105 accepted legacy combat event skipped: %s"
+                   % type(exc).__name__,
+                   category="combat_events",
+               )
+
        # Process the validated response
        try:
            round_advanced_this_response = False

--- a/core/managers/combat_manager.py
+++ b/core/managers/combat_manager.py
@@ -4167,6 +4167,43 @@ Player: {initial_prompt_text}"""
                path_manager,
                monster_templates,
            )
+           # T105: build the per-turn NPC-voice advisory batch (flag-gated,
+           # fail-open) and hand the accepted intents to the agentic intent
+           # model as advisory-only input. Voice never breaks the combat turn.
+           npc_voice_intents = {}
+           if (
+               getattr(config, "NPC_VOICE_ENABLED", False) is True
+               and agentic_recovery["action"] in {"continue", "regenerate_intent"}
+           ):
+               try:
+                   from core.npc.voice_context import (
+                       commit_accepted_combat_voice_batch,
+                       run_combat_voice_stage,
+                   )
+
+                   voice_stage = run_combat_voice_stage(
+                       recovery_action_name=agentic_recovery["action"],
+                       encounter_data=encounter_data,
+                       actor_ids=agentic_actor_ids,
+                       character_paths=character_paths,
+                       context_sheets=context_sheets,
+                       party_tracker_data=party_tracker_data,
+                       location_info=location_info,
+                       player_input=raw_combat_input_text,
+                   )
+                   npc_voice_intents = voice_stage.intents
+                   # T104 can classify only the prior committed fact carried
+                   # by its packet, so this idempotent write cannot depend on
+                   # or make claims about the unresolved T096 action.
+                   commit_accepted_combat_voice_batch(
+                       voice_stage.batch,
+                       party_tracker_data,
+                   )
+               except Exception as exc:
+                   debug(
+                       "T105 combat stage skipped: %s" % type(exc).__name__,
+                       category="combat_events",
+                   )
            try:
                from core.ai.combat_agent import build_contextual_spell_payload
 
@@ -4211,6 +4248,7 @@ Player: {initial_prompt_text}"""
                        "historyInput": user_input_text,
                        "displayPrefix": skipped_player_notice or "",
                    },
+                   npc_voice_intents=npc_voice_intents,
                )
            except (CombatTurnPaused, CombatTransactionError) as exc:
                # Technical exception text may contain internal state terms,

--- a/core/managers/combat_orchestrator.py
+++ b/core/managers/combat_orchestrator.py
@@ -7,6 +7,7 @@
 from copy import deepcopy
 import re
 import time
+from types import MappingProxyType
 
 from core.ai.combat_diagnostics import record_combat_diagnostic
 from core.combat import (
@@ -68,6 +69,26 @@ def _window_kind(encounter, actor_ids):
     if not actors:
         return "clock"
     return "player" if any(actor and actor.get("type") == "player" for actor in actors) else "npc"
+
+
+def _immutable_voice_intents(npc_voice_intents):
+    """Copy once at the coordinator boundary, then reuse unchanged on retries."""
+    if not isinstance(npc_voice_intents, dict):
+        try:
+            npc_voice_intents = dict(npc_voice_intents or {})
+        except (TypeError, ValueError):
+            npc_voice_intents = {}
+    frozen = {}
+    for actor_id, row in npc_voice_intents.items():
+        if not isinstance(actor_id, str):
+            continue
+        if not isinstance(row, dict):
+            try:
+                row = dict(row)
+            except (TypeError, ValueError):
+                continue
+        frozen[actor_id] = MappingProxyType(dict(row))
+    return MappingProxyType(frozen)
 
 
 def _diagnostic_context_counts(spell_references):
@@ -811,6 +832,7 @@ def execute_agentic_turn(
     max_narration_attempts=3,
     intent_provider=None,
     narrator=None,
+    npc_voice_intents=None,
 ):
     """Choose, resolve, commit, then narrate one persisted actor window.
 
@@ -819,6 +841,7 @@ def execute_agentic_turn(
     exhaustion during a player window pauses without consuming the player's
     turn. NPC-only windows fall back to deterministic defend events.
     """
+    immutable_voice_intents = _immutable_voice_intents(npc_voice_intents)
     narrator_is_default = narrator is None
     narration_diagnostics = {} if narrator_is_default else None
     intent_provider_name = "custom"
@@ -1103,13 +1126,20 @@ def execute_agentic_turn(
         started = time.monotonic()
         batch = None
         try:
+            intent_kwargs = {
+                "spell_references": spell_references,
+                "correction": correction,
+            }
+            # T105: pass the immutable NPC-voice advisory map (built once at the
+            # coordinator boundary) unchanged on every intent attempt/correction.
+            if immutable_voice_intents:
+                intent_kwargs["npc_voice_intents"] = immutable_voice_intents
             batch = intent_provider(
                 encounter,
                 provider_characters,
                 pending,
                 provider_player_input,
-                spell_references=spell_references,
-                correction=correction,
+                **intent_kwargs,
             )
             batch = _apply_trusted_spell_durations(
                 batch,

--- a/core/npc/__init__.py
+++ b/core/npc/__init__.py
@@ -1,0 +1,1 @@
+"""Private NPC voice enrichment."""

--- a/core/npc/profile_service.py
+++ b/core/npc/profile_service.py
@@ -1,0 +1,384 @@
+"""One-time, fail-open T107 structured NPC profile seeding."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from jsonschema import Draft202012Validator
+
+import model_config
+from core.ai import api_client
+from core.npc.relationship_store import RelationshipStore
+from core.npc.voice_contracts import STRUCTURED_PROFILE_SCHEMA, canonical_hash
+from utils.capture.multi_model_capture import capture_and_fanout, register_callsite
+
+
+TASK_ID = "T107"
+PROFILE_VERSION = 1
+PROMPT_VERSION = "npc-profile-seed-prompt/v1"
+SCHEMA_VERSION = "npc-profile-seed-response/v1"
+TEMPERATURE = 0.4
+MAX_OUTPUT_TOKENS = 500
+MAX_ATTEMPTS = 2
+MAX_SOURCE_CHARS = 9000
+
+register_callsite("T107", "core/npc/profile_service.py", 292)
+
+
+class ProfileContractError(ValueError):
+    """A T107 source or response violated its strict private contract."""
+
+
+class NpcProfileUnavailable(RuntimeError):
+    """Both bounded T107 attempts failed."""
+
+
+@dataclass(frozen=True)
+class ProfileSeedResult:
+    profile: Dict[str, Any]
+    source_hash: str
+    model: str = ""
+    cached: bool = False
+
+
+class ProfileCache:
+    """Process-local LRU containing validated T107 results only."""
+
+    def __init__(self, max_entries: int = 64) -> None:
+        self.max_entries = max_entries
+        self._values: OrderedDict[str, ProfileSeedResult] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: str) -> Optional[ProfileSeedResult]:
+        with self._lock:
+            value = self._values.get(key)
+            if value is None:
+                return None
+            self._values.move_to_end(key)
+            return copy.deepcopy(value)
+
+    def put(self, key: str, value: ProfileSeedResult) -> None:
+        with self._lock:
+            self._values[key] = copy.deepcopy(value)
+            self._values.move_to_end(key)
+            while len(self._values) > self.max_entries:
+                self._values.popitem(last=False)
+
+
+def _strip_json_fence(value: str) -> str:
+    return re.sub(
+        r"^```(?:json)?\s*|\s*```$", "", value.strip(), flags=re.IGNORECASE
+    )
+
+
+def validate_profile(raw: Any) -> Dict[str, Any]:
+    try:
+        candidate = json.loads(_strip_json_fence(raw)) if isinstance(raw, str) else raw
+    except json.JSONDecodeError as exc:
+        raise ProfileContractError("profile response is not JSON") from exc
+    error = next(Draft202012Validator(STRUCTURED_PROFILE_SCHEMA).iter_errors(candidate), None)
+    if error is not None:
+        path = ".".join(str(part) for part in error.path) or "response"
+        raise ProfileContractError(
+            "invalid profile response at %s: %s" % (path, error.message)
+        )
+    result = copy.deepcopy(candidate)
+    result["voice"]["cadence"] = result["voice"]["cadence"].strip()
+    result["voice"]["diction"] = result["voice"]["diction"].strip()
+    result["conflictStyle"] = result["conflictStyle"].strip()
+    for key in (
+        "taboos", "goals", "fears", "values", "preferences", "boundaries",
+        "protectionPriorities", "retreatRules", "arcSeeds",
+    ):
+        container = result["voice"] if key == "taboos" else result
+        stripped = [item.strip() for item in container[key]]
+        if any(not item for item in stripped) or len(set(stripped)) != len(stripped):
+            raise ProfileContractError("profile strings must be nonempty and unique")
+        container[key] = stripped
+    return result
+
+
+def _text(value: Any, limit: int) -> str:
+    return value.strip()[:limit] if isinstance(value, str) else ""
+
+
+def _unique(values: Any, count: int, limit: int) -> list[str]:
+    if not isinstance(values, (list, tuple)):
+        values = [values]
+    result = []
+    for value in values:
+        item = _text(value, limit)
+        if item and item not in result:
+            result.append(item)
+        if len(result) >= count:
+            break
+    return result
+
+
+def profile_source_hash(source: Mapping[str, Any]) -> str:
+    return canonical_hash({"profileVersion": PROFILE_VERSION, "source": source})
+
+
+def deterministic_fallback_profile(
+    sheet: Mapping[str, Any],
+    lifecycle: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Derive a schema-valid profile without inventing campaign facts."""
+    context = lifecycle if isinstance(lifecycle, Mapping) else {}
+    personality = _text(
+        sheet.get("personality_traits") or sheet.get("personality"), 120
+    )
+    bonds = _text(sheet.get("bonds"), 180)
+    ideals = _text(sheet.get("ideals"), 120)
+    role = _text(sheet.get("role") or sheet.get("class"), 120)
+    objective = _text(context.get("personalObjective"), 180)
+    goals = _unique([objective, bonds, role, ideals, "unknown"], 3, 180)
+    values = _unique([ideals, _text(sheet.get("alignment"), 120), "unknown"], 5, 120)
+    red_lines = _unique(context.get("redLines", []), 5, 160)
+    return {
+        "voice": {"cadence": personality, "diction": "", "taboos": []},
+        "goals": goals,
+        "fears": [],
+        "values": values,
+        "preferences": [],
+        "boundaries": red_lines,
+        "conflictStyle": "",
+        "initiativeTendency": "balanced",
+        "riskTolerance": "measured",
+        "protectionPriorities": [],
+        "retreatRules": [],
+        "arcSeeds": [],
+    }
+
+
+_SOURCE_SHEET_FIELDS = (
+    "name", "race", "class", "subclass", "role", "alignment", "background",
+    "personality_traits", "personality", "ideals", "bonds", "flaws",
+    "skills", "proficiencies", "features", "classFeatures",
+)
+
+
+def build_profile_source(
+    *,
+    npc_id: str,
+    npc_name: str,
+    sheet: Mapping[str, Any],
+    lifecycle: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    if not isinstance(sheet, Mapping):
+        raise ProfileContractError("profile source sheet must be an object")
+    lifecycle_value = dict(lifecycle) if isinstance(lifecycle, Mapping) else {}
+    compact_sheet = {
+        key: copy.deepcopy(sheet[key])
+        for key in _SOURCE_SHEET_FIELDS
+        if key in sheet
+    }
+    source = {
+        "npcId": _text(npc_id, 240),
+        "npcName": _text(npc_name, 100),
+        "sheet": compact_sheet,
+        "lifecycle": lifecycle_value,
+    }
+    if not source["npcId"] or not source["npcName"]:
+        raise ProfileContractError("profile source identity is required")
+    encoded = json.dumps(source, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    if len(encoded) > MAX_SOURCE_CHARS:
+        for key in ("classFeatures", "features", "proficiencies", "skills"):
+            source["sheet"].pop(key, None)
+            encoded = json.dumps(
+                source, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+            )
+            if len(encoded) <= MAX_SOURCE_CHARS:
+                break
+    if len(encoded) > MAX_SOURCE_CHARS:
+        raise ProfileContractError("profile source exceeds T107 input budget")
+    return source
+
+
+def _prompt_text() -> str:
+    path = Path(__file__).resolve().parents[2] / "prompts" / "npc" / "npc_profile_seed_t107.txt"
+    return path.read_text(encoding="ascii").strip()
+
+
+def build_messages(source: Mapping[str, Any], retry_reason: str = "") -> list[Dict[str, str]]:
+    messages = [{"role": "system", "content": _prompt_text()}]
+    if retry_reason:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "The previous private response failed the strict contract (%s). "
+                    "Return one corrected exact JSON object only." % retry_reason
+                ),
+            }
+        )
+    messages.append(
+        {
+            "role": "user",
+            "content": json.dumps(
+                source, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+            ),
+        }
+    )
+    return messages
+
+
+def _config_for_provider(provider: str) -> Dict[str, Any]:
+    if provider == "openai":
+        selected = model_config.NPC_PROFILE_T107_OPENAI_LUNA_NONE
+    elif provider == "gemini":
+        selected = model_config.NPC_PROFILE_T107_GEMINI_FLASHLITE_LOW
+    elif provider == "legacy":
+        selected = model_config.NPC_PROFILE_T107_LEGACY
+    elif provider == "lmstudio":
+        selected = model_config.NPC_PROFILE_T107_LMSTUDIO
+    else:
+        raise ValueError("unsupported T107 provider: %s" % provider)
+    return copy.deepcopy(selected)
+
+
+class NpcProfileService:
+    def __init__(
+        self,
+        completion_fn: Callable[..., Any] = api_client.create_completion,
+        *,
+        capture_fn: Callable[..., Any] = capture_and_fanout,
+        cache: Optional[ProfileCache] = None,
+    ) -> None:
+        self.completion_fn = completion_fn
+        self.capture_fn = capture_fn
+        self.cache = cache if cache is not None else ProfileCache()
+
+    def seed(
+        self,
+        source: Mapping[str, Any],
+        *,
+        source_hash_override: str = "",
+    ) -> ProfileSeedResult:
+        if not isinstance(source, Mapping):
+            raise ProfileContractError("profile source must be an object")
+        required = {"npcId", "npcName", "sheet", "lifecycle"}
+        if set(source) != required:
+            raise ProfileContractError("profile source keys are invalid")
+        source_copy = copy.deepcopy(dict(source))
+        source_digest = (
+            source_hash_override
+            if re.fullmatch(r"[0-9a-f]{64}", source_hash_override or "")
+            else profile_source_hash(source_copy)
+        )
+        cached = self.cache.get(source_digest)
+        if cached is not None:
+            return ProfileSeedResult(
+                profile=cached.profile,
+                source_hash=cached.source_hash,
+                model=cached.model,
+                cached=True,
+            )
+        provider = model_config.get_provider()
+        last_error: Optional[BaseException] = None
+        retry_reason = ""
+        for attempt in range(MAX_ATTEMPTS):
+            config = _config_for_provider(provider)
+            model = config.pop("model")
+            response = None
+            try:
+                response = self.capture_fn(
+                    TASK_ID,
+                    self.completion_fn,
+                    _request_provider=provider,
+                    messages=build_messages(source_copy, retry_reason),
+                    model=model,
+                    temperature=TEMPERATURE,
+                    max_tokens=MAX_OUTPUT_TOKENS,
+                    retry_attempt=attempt,
+                    **config,
+                )
+                profile = validate_profile(response.choices[0].message.content)
+                result = ProfileSeedResult(
+                    profile=profile,
+                    source_hash=source_digest,
+                    model=getattr(response, "model", None) or model,
+                )
+                self.cache.put(source_digest, result)
+                return result
+            except ProfileContractError as exc:
+                last_error = exc
+                retry_reason = "invalid_contract"
+            except Exception as exc:
+                last_error = exc
+                retry_reason = "provider_failure"
+        raise NpcProfileUnavailable("T107 attempts exhausted") from last_error
+
+
+_DEFAULT_SERVICE: Optional[NpcProfileService] = None
+_DEFAULT_SERVICE_LOCK = threading.Lock()
+
+
+def _default_service() -> NpcProfileService:
+    global _DEFAULT_SERVICE
+    with _DEFAULT_SERVICE_LOCK:
+        if _DEFAULT_SERVICE is None:
+            _DEFAULT_SERVICE = NpcProfileService()
+        return _DEFAULT_SERVICE
+
+
+def seed_profile_best_effort(
+    *,
+    store: RelationshipStore,
+    npc_id: str,
+    npc_name: str,
+    sheet: Mapping[str, Any],
+    lifecycle: Optional[Mapping[str, Any]] = None,
+    service: Optional[NpcProfileService] = None,
+) -> Dict[str, Any]:
+    """Persist fallback first; T107 failure can never undo recruitment."""
+    lifecycle_value = dict(lifecycle) if isinstance(lifecycle, Mapping) else {}
+    full_hash_source = {
+        "npcId": npc_id,
+        "npcName": npc_name,
+        "sheet": dict(sheet),
+        "lifecycle": lifecycle_value,
+    }
+    source_digest = profile_source_hash(full_hash_source)
+    existing = store.get_profile(npc_id)
+    if (
+        isinstance(existing, dict)
+        and existing.get("profileVersion") == PROFILE_VERSION
+        and existing.get("sourceHash") == source_digest
+    ):
+        return existing
+    fallback = deterministic_fallback_profile(sheet, lifecycle_value)
+    persisted_fallback = {
+        "profileVersion": PROFILE_VERSION,
+        "sourceHash": source_digest,
+        **fallback,
+    }
+    store.store_profile(npc_id, persisted_fallback)
+    try:
+        source = build_profile_source(
+            npc_id=npc_id,
+            npc_name=npc_name,
+            sheet=sheet,
+            lifecycle=lifecycle_value,
+        )
+        # Bind the compact request to the full authoritative source hash so
+        # mechanical sheet changes still invalidate a prior seed.
+        result = (service or _default_service()).seed(
+            source, source_hash_override=source_digest
+        )
+        seeded = {
+            "profileVersion": PROFILE_VERSION,
+            "sourceHash": source_digest,
+            **result.profile,
+        }
+        store.store_profile(npc_id, seeded)
+        return store.get_profile(npc_id) or persisted_fallback
+    except Exception:
+        return store.get_profile(npc_id) or persisted_fallback

--- a/core/npc/profile_service.py
+++ b/core/npc/profile_service.py
@@ -307,7 +307,9 @@ class NpcProfileService:
                     messages=build_messages(source_copy, retry_reason),
                     model=model,
                     temperature=TEMPERATURE,
-                    max_tokens=MAX_OUTPUT_TOKENS,
+                    # No max_tokens/max_completion_tokens on any call: gpt-5.x (luna)
+                    # rejects max_tokens with a 400. Structured output is bounded by
+                    # the client-side profile contract validation instead.
                     retry_attempt=attempt,
                     **config,
                 )

--- a/core/npc/profile_service.py
+++ b/core/npc/profile_service.py
@@ -16,7 +16,11 @@ from jsonschema import Draft202012Validator
 import model_config
 from core.ai import api_client
 from core.npc.relationship_store import RelationshipStore
-from core.npc.voice_contracts import STRUCTURED_PROFILE_SCHEMA, canonical_hash
+from core.npc.voice_contracts import (
+    STRUCTURED_PROFILE_SCHEMA,
+    canonical_hash,
+    profile_gemini_response_schema,
+)
 from utils.capture.multi_model_capture import capture_and_fanout, register_callsite
 
 
@@ -231,17 +235,24 @@ def build_messages(source: Mapping[str, Any], retry_reason: str = "") -> list[Di
 
 
 def _config_for_provider(provider: str) -> Dict[str, Any]:
+    # Structured 12-key profile output. OpenAI/legacy use JSON mode + client-side
+    # validation; Gemini needs response_schema or it emits the wrong shape.
+    # Never attach response_schema on the OpenAI path (would 400).
     if provider == "openai":
-        selected = model_config.NPC_PROFILE_T107_OPENAI_LUNA_NONE
+        selected = copy.deepcopy(model_config.NPC_PROFILE_T107_OPENAI_LUNA_NONE)
+        selected["response_format"] = {"type": "json_object"}
     elif provider == "gemini":
-        selected = model_config.NPC_PROFILE_T107_GEMINI_FLASHLITE_LOW
+        selected = copy.deepcopy(model_config.NPC_PROFILE_T107_GEMINI_FLASHLITE_LOW)
+        selected["response_schema"] = profile_gemini_response_schema()
     elif provider == "legacy":
-        selected = model_config.NPC_PROFILE_T107_LEGACY
+        selected = copy.deepcopy(model_config.NPC_PROFILE_T107_LEGACY)
+        selected["response_format"] = {"type": "json_object"}
     elif provider == "lmstudio":
-        selected = model_config.NPC_PROFILE_T107_LMSTUDIO
+        selected = copy.deepcopy(model_config.NPC_PROFILE_T107_LMSTUDIO)
+        selected["response_format"] = None
     else:
         raise ValueError("unsupported T107 provider: %s" % provider)
-    return copy.deepcopy(selected)
+    return selected
 
 
 class NpcProfileService:

--- a/core/npc/relationship_rules.py
+++ b/core/npc/relationship_rules.py
@@ -1,0 +1,106 @@
+"""Versioned deterministic relationship math for NPC voice state."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+
+DIMENSIONS = ("trust", "power", "intimacy", "fear", "respect")
+
+BOUNDS = {
+    "trust": (-1.0, 1.0),
+    "power": (-1.0, 1.0),
+    "intimacy": (0.0, 1.0),
+    "fear": (0.0, 1.0),
+    "respect": (-1.0, 1.0),
+}
+
+EVENT_DELTAS = {
+    "abandon": {"trust": -0.12, "power": 0.00, "intimacy": -0.05, "fear": 0.04, "respect": -0.08},
+    "betray": {"trust": -0.18, "power": 0.00, "intimacy": -0.07, "fear": 0.04, "respect": -0.12},
+    "deceive": {"trust": -0.12, "power": 0.00, "intimacy": -0.03, "fear": 0.01, "respect": -0.08},
+    "disrespect": {"trust": -0.04, "power": 0.00, "intimacy": -0.04, "fear": 0.00, "respect": -0.12},
+    "harm": {"trust": -0.15, "power": 0.03, "intimacy": -0.06, "fear": 0.12, "respect": -0.10},
+    "threaten": {"trust": -0.10, "power": 0.04, "intimacy": -0.05, "fear": 0.15, "respect": -0.08},
+    "give": {"trust": 0.04, "power": 0.00, "intimacy": 0.02, "fear": 0.00, "respect": 0.02},
+    "heal": {"trust": 0.08, "power": 0.00, "intimacy": 0.04, "fear": -0.02, "respect": 0.05},
+    "honor": {"trust": 0.05, "power": 0.00, "intimacy": 0.03, "fear": -0.01, "respect": 0.10},
+    "protect": {"trust": 0.10, "power": 0.01, "intimacy": 0.05, "fear": -0.03, "respect": 0.08},
+    "rescue": {"trust": 0.14, "power": 0.02, "intimacy": 0.07, "fear": -0.04, "respect": 0.10},
+    "share": {"trust": 0.05, "power": 0.00, "intimacy": 0.05, "fear": 0.00, "respect": 0.03},
+    "support": {"trust": 0.07, "power": 0.00, "intimacy": 0.04, "fear": -0.01, "respect": 0.05},
+    "trust": {"trust": 0.08, "power": 0.00, "intimacy": 0.06, "fear": -0.01, "respect": 0.04},
+}
+
+
+def _number(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    return float(value)
+
+
+def clamp_state(state: Mapping[str, object]) -> Dict[str, float]:
+    """Clamp and round one complete five-dimensional state."""
+    result = {}
+    for name in DIMENSIONS:
+        minimum, maximum = BOUNDS[name]
+        result[name] = round(max(minimum, min(maximum, _number(state.get(name)))), 4)
+    return result
+
+
+def apply_event_delta(
+    current: Mapping[str, object],
+    event_type: str,
+    magnitude: int,
+    *,
+    witnessed: bool,
+) -> Dict[str, float]:
+    """Apply one v1 event without mutating the input state."""
+    if event_type not in EVENT_DELTAS:
+        raise ValueError("unknown relationship event type")
+    if isinstance(magnitude, bool) or not isinstance(magnitude, int):
+        raise ValueError("relationship magnitude must be an integer")
+    strength = abs(magnitude)
+    if strength not in (1, 2, 3):
+        raise ValueError("relationship magnitude must be 1 through 3")
+    base = clamp_state(current)
+    if not witnessed:
+        return base
+    delta = EVENT_DELTAS[event_type]
+    return clamp_state(
+        {name: base[name] + delta[name] * strength for name in DIMENSIONS}
+    )
+
+
+def event_delta(event_type: str, magnitude: int, witnessed: bool) -> Dict[str, float]:
+    """Return the bounded event delta recorded in evidence."""
+    zero = {name: 0.0 for name in DIMENSIONS}
+    if not witnessed:
+        return zero
+    applied = apply_event_delta(zero, event_type, magnitude, witnessed=True)
+    raw = EVENT_DELTAS[event_type]
+    return {
+        name: round(raw[name] * abs(magnitude), 4)
+        for name in DIMENSIONS
+    }
+
+
+def decay_toward_baseline(
+    baseline: Mapping[str, object],
+    current: Mapping[str, object],
+    elapsed_game_days: int,
+) -> Dict[str, float]:
+    """Apply lazy 3 percent daily decay toward an edge's baseline."""
+    base = clamp_state(baseline)
+    now = clamp_state(current)
+    if isinstance(elapsed_game_days, bool) or not isinstance(elapsed_game_days, int):
+        raise ValueError("elapsed game days must be an integer")
+    if elapsed_game_days <= 0:
+        return now
+    multiplier = 0.97 ** elapsed_game_days
+    return clamp_state(
+        {
+            name: base[name] + (now[name] - base[name]) * multiplier
+            for name in DIMENSIONS
+        }
+    )

--- a/core/npc/relationship_store.py
+++ b/core/npc/relationship_store.py
@@ -1,0 +1,1226 @@
+"""Strict, atomic, revisioned persistence for private NPC relationship state."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Tuple
+
+from jsonschema import Draft202012Validator
+
+from core.effects.clock import SECONDS_PER_DAY, scalar_from_calendar
+from core.npc.relationship_rules import (
+    DIMENSIONS,
+    EVENT_DELTAS,
+    apply_event_delta,
+    clamp_state,
+    decay_toward_baseline,
+    event_delta,
+)
+from core.npc.voice_contracts import (
+    NEGATIVE_AFFINITY_EVENT_TYPES,
+    POSITIVE_AFFINITY_EVENT_TYPES,
+    PROMPT_VERSION,
+)
+from utils.encoding_utils import safe_json_dump
+from utils.path_transaction_lock import path_transaction_lock
+
+
+_LOGGER = logging.getLogger(__name__)
+SCHEMA_VERSION = 1
+MIGRATION_VERSION = "companion-memory-v1"
+DEFAULT_STATE_PATH = Path("data/companion_memories/npc_agent_state.json")
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "npc_agent_state_schema.json"
+PROJECT_IDENTITY_NAMESPACE = uuid.UUID("9b0f3d4d-bf49-5c2c-a8bb-4056bdc31fc1")
+ZERO_HASH = "0" * 64
+UNRESOLVED_TYPES = frozenset({"abandon", "betray", "rescue"})
+
+
+@dataclass(frozen=True)
+class EventApplication:
+    event_id: str
+    mutated: bool
+    duplicate: bool = False
+    read_only: bool = False
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_value(value: Any) -> str:
+    return _sha256_bytes(_canonical_json(value).encode("ascii"))
+
+
+def _text(value: Any, limit: int) -> str:
+    return value.strip()[:limit] if isinstance(value, str) else ""
+
+
+def _text_list(value: Any, count: int, limit: int) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    result = []
+    for item in value:
+        candidate = _text(item, limit)
+        if candidate and candidate not in result:
+            result.append(candidate)
+        if len(result) >= count:
+            break
+    return result
+
+
+def normalize_identity_seed(sheet_path: os.PathLike[str] | str) -> str:
+    """Return a stable, root-relative, slash-normalized identity seed."""
+    raw = os.fspath(sheet_path)
+    normalized = os.path.normpath(raw)
+    if os.path.isabs(normalized):
+        try:
+            normalized = os.path.relpath(normalized, os.getcwd())
+        except ValueError:
+            pass
+    while normalized.startswith("./") or normalized.startswith(".\\"):
+        normalized = normalized[2:]
+    return normalized.replace("\\", "/").casefold()
+
+
+def stable_identity_id(kind: str, sheet_path: os.PathLike[str] | str) -> str:
+    if kind not in {"npc", "player"}:
+        raise ValueError("identity kind must be npc or player")
+    seed = normalize_identity_seed(sheet_path)
+    if not seed or seed == ".":
+        raise ValueError("identity seed must name a character sheet")
+    return str(uuid.uuid5(PROJECT_IDENTITY_NAMESPACE, "%s:%s" % (kind, seed)))
+
+
+def game_day_ordinal(world_conditions: Mapping[str, Any]) -> Optional[int]:
+    """Convert an exact persisted calendar date to an ordinal, or return None."""
+    if not isinstance(world_conditions, Mapping):
+        return None
+    if not all(name in world_conditions for name in ("year", "month", "day")):
+        return None
+    try:
+        return scalar_from_calendar(dict(world_conditions)) // SECONDS_PER_DAY
+    except (TypeError, ValueError):
+        return None
+
+
+def _neutral() -> Dict[str, float]:
+    return {name: 0.0 for name in DIMENSIONS}
+
+
+def new_state_document() -> Dict[str, Any]:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "revision": 0,
+        "identities": {},
+        "profiles": {},
+        "relationships": {},
+        "working": {},
+        "lifecycle": {},
+        "migrations": {},
+    }
+
+
+def _relationship_key(subject_id: str, counterparty_id: str) -> str:
+    return "%s|%s" % (subject_id, counterparty_id)
+
+
+def _new_relationship(
+    subject_id: str,
+    counterparty_id: str,
+    game_day: Optional[int],
+) -> Dict[str, Any]:
+    return {
+        "subjectId": subject_id,
+        "counterpartyId": counterparty_id,
+        "baseline": _neutral(),
+        "current": _neutral(),
+        "lastDecayDay": game_day,
+        "evidence": [],
+        "appliedEventIds": [],
+        "appliedEventHistory": ZERO_HASH,
+        "aggregateCounts": {},
+        "evidenceHashChain": ZERO_HASH,
+    }
+
+
+def _identity_names(identity: Mapping[str, Any]) -> set[str]:
+    names = {_text(identity.get("displayName"), 100)}
+    names.update(
+        _text(value, 100)
+        for value in identity.get("aliases", [])
+        if isinstance(value, str)
+    )
+    return {name for name in names if name}
+
+
+def _history_contains(history: str, event_id: str) -> bool:
+    bits = int(history or ZERO_HASH, 16)
+    index = int(event_id[:8], 16) % 256
+    return bool(bits & (1 << index))
+
+
+def _history_add(history: str, event_id: str) -> str:
+    bits = int(history or ZERO_HASH, 16)
+    index = int(event_id[:8], 16) % 256
+    return format(bits | (1 << index), "064x")
+
+
+class RelationshipStore:
+    """One path-scoped sidecar with fail-closed writes and fail-open reads."""
+
+    def __init__(
+        self,
+        path: os.PathLike[str] | str = DEFAULT_STATE_PATH,
+        *,
+        schema_path: os.PathLike[str] | str = DEFAULT_SCHEMA_PATH,
+    ) -> None:
+        self.path = Path(path)
+        self.schema_path = Path(schema_path)
+        schema = json.loads(self.schema_path.read_text(encoding="ascii"))
+        self._validator = Draft202012Validator(schema)
+        self._read_only_reason: Optional[str] = None
+        if self.path.exists():
+            document = self._read_existing()
+            if document is None:
+                self._read_only_reason = "corrupt_or_unsupported"
+
+    @property
+    def read_only(self) -> bool:
+        return self._read_only_reason is not None
+
+    @property
+    def read_only_reason(self) -> Optional[str]:
+        return self._read_only_reason
+
+    def _validate(self, document: Mapping[str, Any]) -> bool:
+        if document.get("schemaVersion") != SCHEMA_VERSION:
+            return False
+        return next(self._validator.iter_errors(document), None) is None
+
+    def _read_existing(self) -> Optional[Dict[str, Any]]:
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                value = json.load(handle)
+        except (OSError, ValueError, TypeError):
+            return None
+        if not isinstance(value, dict):
+            return None
+        if self._validate(value):
+            return value
+        return self._repair_bounded_working_text(value)
+
+    def _repair_bounded_working_text(
+        self, document: Mapping[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Recover only historical working-text overflows, never unknown damage."""
+        bounds = {
+            "currentPrivateIntent": 300,
+            "sourceTurn": 120,
+            "currentGoalReference": 300,
+            "openQuestion": 240,
+            "sceneId": 240,
+        }
+        errors = list(self._validator.iter_errors(document))
+        if not errors:
+            return copy.deepcopy(dict(document))
+        candidate = copy.deepcopy(dict(document))
+        for validation_error in errors:
+            path = list(validation_error.absolute_path)
+            if (
+                validation_error.validator != "maxLength"
+                or len(path) != 3
+                or path[0] != "working"
+                or path[2] not in bounds
+            ):
+                return None
+            row = candidate.get("working", {}).get(path[1])
+            value = row.get(path[2]) if isinstance(row, dict) else None
+            if not isinstance(value, str):
+                return None
+            row[path[2]] = value[: bounds[path[2]]]
+        return candidate if self._validate(candidate) else None
+
+    def snapshot(self) -> Dict[str, Any]:
+        value = self._read_existing() if self.path.exists() else None
+        return copy.deepcopy(value if value is not None else new_state_document())
+
+    def _mutate(
+        self,
+        callback: Callable[[Dict[str, Any]], Tuple[bool, Any]],
+    ) -> Tuple[bool, Any]:
+        if self.read_only:
+            return False, None
+        try:
+            with path_transaction_lock(
+                self.path,
+                suffix=".npc-agent.lock",
+                timeout_seconds=5.0,
+            ) as acquired:
+                if acquired is None:
+                    return False, None
+                if self.path.exists():
+                    current = self._read_existing()
+                    if current is None:
+                        self._read_only_reason = "corrupt_or_unsupported"
+                        return False, None
+                else:
+                    current = new_state_document()
+                candidate = copy.deepcopy(current)
+                changed, result = callback(candidate)
+                if not changed:
+                    return False, result
+                candidate["revision"] = current["revision"] + 1
+                if not self._validate(candidate):
+                    return False, result
+                try:
+                    safe_json_dump(candidate, self.path, ensure_ascii=True)
+                except Exception:
+                    _LOGGER.warning("NPC relationship state write failed")
+                    return False, result
+                return True, result
+        except Exception:
+            _LOGGER.warning("NPC relationship state mutation failed")
+            return False, None
+
+    def _resolve_existing_identity(
+        self,
+        document: Mapping[str, Any],
+        *,
+        kind: str,
+        display_name: str,
+        sheet_path: str,
+    ) -> Optional[str]:
+        identities = document["identities"]
+        normalized_path = normalize_identity_seed(sheet_path)
+        path_matches = [
+            identity_id
+            for identity_id, identity in identities.items()
+            if identity.get("kind") == kind
+            and normalize_identity_seed(identity.get("sheetPath", ""))
+            == normalized_path
+        ]
+        if len(path_matches) == 1:
+            return path_matches[0]
+        name_matches = [
+            identity_id
+            for identity_id, identity in identities.items()
+            if identity.get("kind") == kind
+            and display_name in _identity_names(identity)
+        ]
+        if len(name_matches) == 1:
+            return name_matches[0]
+        if len(path_matches) > 1 or len(name_matches) > 1:
+            raise ValueError("ambiguous stable identity")
+        return None
+
+    def ensure_identity(
+        self,
+        *,
+        kind: str,
+        display_name: str,
+        sheet_path: os.PathLike[str] | str,
+        module: str = "",
+        location_id: str = "",
+        active: Optional[bool] = True,
+    ) -> str:
+        display_name = _text(display_name, 100)
+        normalized_path = normalize_identity_seed(sheet_path)
+        if not display_name:
+            raise ValueError("identity display name is required")
+        proposed_id = stable_identity_id(kind, normalized_path)
+        snapshot = self.snapshot()
+        try:
+            existing_id = self._resolve_existing_identity(
+                snapshot,
+                kind=kind,
+                display_name=display_name,
+                sheet_path=normalized_path,
+            )
+        except ValueError:
+            raise
+        identity_id = existing_id or proposed_id
+        if self.read_only:
+            return identity_id
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, str]:
+            resolved = self._resolve_existing_identity(
+                document,
+                kind=kind,
+                display_name=display_name,
+                sheet_path=normalized_path,
+            )
+            selected_id = resolved or identity_id
+            identity = document["identities"].get(selected_id)
+            if identity is None:
+                document["identities"][selected_id] = {
+                    "kind": kind,
+                    "displayName": display_name,
+                    "aliases": [],
+                    "sheetPath": normalized_path,
+                    "identitySeed": normalized_path,
+                    "active": True if active is None else bool(active),
+                    "lastModule": _text(module, 160),
+                    "lastLocationId": _text(location_id, 120),
+                }
+                if kind == "npc":
+                    document["lifecycle"][selected_id] = {
+                        "status": "active" if active is not False else "inactive",
+                        "events": [],
+                    }
+                return True, selected_id
+            before = copy.deepcopy(identity)
+            old_name = identity["displayName"]
+            if old_name != display_name and old_name not in identity["aliases"]:
+                identity["aliases"].append(old_name)
+                identity["aliases"] = identity["aliases"][-32:]
+            identity["displayName"] = display_name
+            identity["sheetPath"] = normalized_path
+            if active is not None:
+                identity["active"] = bool(active)
+            identity["lastModule"] = _text(module, 160)
+            identity["lastLocationId"] = _text(location_id, 120)
+            lifecycle_changed = False
+            if kind == "npc":
+                lifecycle = document["lifecycle"].setdefault(
+                    selected_id, {"status": "active", "events": []}
+                )
+                if active is not None:
+                    prior_lifecycle_status = lifecycle.get("status")
+                    lifecycle["status"] = "active" if active else "inactive"
+                    lifecycle_changed = lifecycle["status"] != prior_lifecycle_status
+            return before != identity or lifecycle_changed, selected_id
+
+        _changed, actual_id = self._mutate(update)
+        return actual_id or identity_id
+
+    def _ensure_edge(
+        self,
+        document: Dict[str, Any],
+        subject_id: str,
+        counterparty_id: str,
+        game_day: Optional[int],
+    ) -> Tuple[Dict[str, Any], bool]:
+        if subject_id == counterparty_id:
+            raise ValueError("relationship endpoints must differ")
+        if (
+            subject_id not in document["identities"]
+            or counterparty_id not in document["identities"]
+        ):
+            raise ValueError("relationship endpoints must be registered identities")
+        key = _relationship_key(subject_id, counterparty_id)
+        if key not in document["relationships"]:
+            document["relationships"][key] = _new_relationship(
+                subject_id, counterparty_id, game_day
+            )
+            return document["relationships"][key], True
+        return document["relationships"][key], False
+
+    @staticmethod
+    def _apply_decay(edge: Dict[str, Any], game_day: Optional[int]) -> bool:
+        if game_day is None:
+            return False
+        last_day = edge.get("lastDecayDay")
+        if last_day is None:
+            edge["lastDecayDay"] = game_day
+            return True
+        if game_day <= last_day:
+            return False
+        edge["current"] = decay_toward_baseline(
+            edge["baseline"], edge["current"], game_day - last_day
+        )
+        edge["lastDecayDay"] = game_day
+        return True
+
+    def get_relationship(
+        self,
+        subject_id: str,
+        counterparty_id: str,
+        *,
+        game_day: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        holder: Dict[str, Any] = {}
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, None]:
+            edge, created = self._ensure_edge(
+                document, subject_id, counterparty_id, game_day
+            )
+            decayed = self._apply_decay(edge, game_day)
+            holder["edge"] = copy.deepcopy(edge)
+            return created or decayed, None
+
+        if self.read_only:
+            snapshot = self.snapshot()
+            edge = snapshot["relationships"].get(
+                _relationship_key(subject_id, counterparty_id)
+            )
+            return copy.deepcopy(
+                edge or _new_relationship(subject_id, counterparty_id, game_day)
+            )
+        self._mutate(update)
+        return holder.get(
+            "edge", _new_relationship(subject_id, counterparty_id, game_day)
+        )
+
+    def get_profile(self, npc_id: str) -> Optional[Dict[str, Any]]:
+        """Return one validated persisted profile without exposing live state."""
+        profile = self.snapshot()["profiles"].get(npc_id)
+        return copy.deepcopy(profile) if isinstance(profile, dict) else None
+
+    def store_profile(self, npc_id: str, profile: Mapping[str, Any]) -> bool:
+        """Atomically replace one profile after whole-document validation."""
+        candidate = copy.deepcopy(dict(profile)) if isinstance(profile, Mapping) else {}
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, None]:
+            identity = document["identities"].get(npc_id)
+            if not identity or identity.get("kind") != "npc":
+                return False, None
+            if document["profiles"].get(npc_id) == candidate:
+                return False, None
+            document["profiles"][npc_id] = candidate
+            return True, None
+
+        mutated, _ = self._mutate(update)
+        return mutated
+
+    def _event_id(
+        self,
+        source_turn_id: str,
+        subject_id: str,
+        counterparty_id: str,
+        event: Mapping[str, Any],
+        prompt_version: str,
+    ) -> str:
+        return _sha256_value(
+            [
+                "relationship-event/v2",
+                source_turn_id,
+                subject_id,
+                counterparty_id,
+                prompt_version,
+            ]
+        )
+
+    def _validate_event(
+        self,
+        document: Mapping[str, Any],
+        subject_id: str,
+        counterparty_id: str,
+        event: Mapping[str, Any],
+    ) -> None:
+        if set(event) != {"actor", "target", "eventType", "magnitude", "witnessed"}:
+            raise ValueError("relationship event keys are invalid")
+        subject = document["identities"].get(subject_id)
+        counterparty = document["identities"].get(counterparty_id)
+        if not subject or not counterparty or subject.get("kind") != "npc":
+            raise ValueError("relationship event identity direction is invalid")
+        if event["actor"] not in _identity_names(counterparty):
+            raise ValueError("relationship event actor is not the counterparty")
+        if event["target"] not in _identity_names(subject):
+            raise ValueError("relationship event target is not the focal NPC")
+        event_type = event["eventType"]
+        magnitude = event["magnitude"]
+        if event_type not in EVENT_DELTAS:
+            raise ValueError("relationship event type is invalid")
+        if (
+            isinstance(magnitude, bool)
+            or not isinstance(magnitude, int)
+            or abs(magnitude) not in (1, 2, 3)
+        ):
+            raise ValueError("relationship event magnitude is invalid")
+        if event_type in POSITIVE_AFFINITY_EVENT_TYPES and magnitude < 0:
+            raise ValueError("positive relationship event has negative magnitude")
+        if event_type in NEGATIVE_AFFINITY_EVENT_TYPES and magnitude > 0:
+            raise ValueError("negative relationship event has positive magnitude")
+        if not isinstance(event["witnessed"], bool):
+            raise ValueError("relationship witnessed flag is invalid")
+
+    @staticmethod
+    def _prune_evidence(edge: Dict[str, Any]) -> None:
+        records = edge["evidence"]
+        if len(records) <= 256:
+            edge["appliedEventIds"] = [
+                record["eventId"]
+                for record in records
+                if record["kind"] == "typedEvent"
+            ]
+            return
+        ranked = sorted(
+            enumerate(records),
+            key=lambda row: (
+                row[1]["magnitude"] == 3,
+                row[1]["gameDay"] if row[1]["gameDay"] is not None else -1,
+                row[0],
+            ),
+            reverse=True,
+        )
+        keep_indexes = {index for index, _record in ranked[:256]}
+        kept = []
+        for index, record in enumerate(records):
+            if index in keep_indexes:
+                kept.append(record)
+                continue
+            aggregate_key = record["eventType"] or "legacyEvidence"
+            counts = edge["aggregateCounts"]
+            counts[aggregate_key] = counts.get(aggregate_key, 0) + 1
+            edge["evidenceHashChain"] = _sha256_value(
+                [edge["evidenceHashChain"], record["eventId"]]
+            )
+            if record["kind"] == "typedEvent":
+                edge["appliedEventHistory"] = _history_add(
+                    edge["appliedEventHistory"], record["eventId"]
+                )
+        edge["evidence"] = kept
+        edge["appliedEventIds"] = [
+            record["eventId"]
+            for record in kept
+            if record["kind"] == "typedEvent"
+        ]
+
+    @staticmethod
+    def _set_working(
+        document: Dict[str, Any],
+        npc_id: str,
+        working: Optional[Mapping[str, Any]],
+    ) -> bool:
+        if not working:
+            return False
+        source_turn = _text(working.get("sourceTurn"), 120)
+        intent = _text(working.get("currentPrivateIntent"), 300)
+        if not source_turn or not intent:
+            return False
+        candidate = {
+            "currentPrivateIntent": intent,
+            "sourceTurn": source_turn,
+            "currentGoalReference": _text(working.get("currentGoalReference"), 300),
+            "openQuestion": _text(working.get("openQuestion"), 240),
+            "moodTags": list(dict.fromkeys(
+                _text(value, 60)
+                for value in working.get("moodTags", [])
+                if _text(value, 60)
+            ))[:4],
+            "expiresAfterTurn": working.get("expiresAfterTurn")
+            if isinstance(working.get("expiresAfterTurn"), int)
+            and not isinstance(working.get("expiresAfterTurn"), bool)
+            and working.get("expiresAfterTurn") >= 0
+            else None,
+            "sceneId": _text(working.get("sceneId"), 240),
+        }
+        if document["working"].get(npc_id) == candidate:
+            return False
+        document["working"][npc_id] = candidate
+        return True
+
+    def apply_event(
+        self,
+        *,
+        subject_id: str,
+        counterparty_id: str,
+        event: Mapping[str, Any],
+        source_turn_id: str,
+        evidence_summary: str,
+        game_day: Optional[int],
+        module: str,
+        location_id: str,
+        packet_hash: str,
+        prompt_version: str = PROMPT_VERSION,
+        topic_ids: Iterable[str] = (),
+        working: Optional[Mapping[str, Any]] = None,
+    ) -> EventApplication:
+        source_turn_id = _text(source_turn_id, 120)
+        evidence_summary = _text(evidence_summary, 240)
+        if not source_turn_id or not evidence_summary:
+            raise ValueError("relationship event source and evidence are required")
+        snapshot = self.snapshot()
+        self._validate_event(snapshot, subject_id, counterparty_id, event)
+        event_id = self._event_id(
+            source_turn_id,
+            subject_id,
+            counterparty_id,
+            event,
+            prompt_version,
+        )
+        if self.read_only:
+            return EventApplication(event_id, False, read_only=True)
+        disposition = {"duplicate": False}
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, str]:
+            self._validate_event(document, subject_id, counterparty_id, event)
+            edge, created = self._ensure_edge(
+                document, subject_id, counterparty_id, game_day
+            )
+            prior_source = next(
+                (
+                    record
+                    for record in edge["evidence"]
+                    if record.get("kind") == "typedEvent"
+                    and record.get("sourceTurnId") == source_turn_id
+                ),
+                None,
+            )
+            if prior_source is not None:
+                disposition["duplicate"] = True
+                return False, prior_source["eventId"]
+            if event_id in edge["appliedEventIds"] or _history_contains(
+                edge["appliedEventHistory"], event_id
+            ):
+                disposition["duplicate"] = True
+                return False, event_id
+            changed = created or self._apply_decay(edge, game_day)
+            witnessed = event["witnessed"]
+            before = copy.deepcopy(edge["current"])
+            edge["current"] = apply_event_delta(
+                edge["current"],
+                event["eventType"],
+                event["magnitude"],
+                witnessed=witnessed,
+            )
+            delta = event_delta(
+                event["eventType"], event["magnitude"], witnessed
+            )
+            record = {
+                "kind": "typedEvent",
+                "eventId": event_id,
+                "actorId": counterparty_id,
+                "targetId": subject_id,
+                "actor": event["actor"],
+                "target": event["target"],
+                "eventType": event["eventType"],
+                "magnitude": abs(event["magnitude"]),
+                "witnessed": witnessed,
+                "applied": witnessed,
+                "delta": delta,
+                "summary": evidence_summary,
+                "sourceTurnId": source_turn_id,
+                "promptVersion": _text(prompt_version, 80),
+                "packetHash": packet_hash if len(packet_hash) == 64 else "",
+                "gameDay": game_day,
+                "module": _text(module, 160),
+                "locationId": _text(location_id, 120),
+                "topicIds": list(dict.fromkeys(
+                    _text(value, 240) for value in topic_ids if _text(value, 240)
+                ))[:12],
+                "unresolved": event["eventType"] in UNRESOLVED_TYPES,
+                "sourceHash": "",
+            }
+            edge["evidence"].append(record)
+            edge["appliedEventIds"].append(event_id)
+            self._prune_evidence(edge)
+            changed = True
+            changed = self._set_working(document, subject_id, working) or changed
+            return changed or before != edge["current"], event_id
+
+        mutated, _result = self._mutate(update)
+        return EventApplication(
+            event_id,
+            mutated,
+            duplicate=disposition["duplicate"],
+            read_only=self.read_only,
+        )
+
+    def update_working(
+        self,
+        npc_id: str,
+        *,
+        source_turn_id: str,
+        thought: str,
+        current_goal_reference: str = "",
+        open_question: str = "",
+        mood_tags: Iterable[str] = (),
+        expires_after_turn: Optional[int] = None,
+        scene_id: str = "",
+    ) -> bool:
+        working = {
+            "currentPrivateIntent": thought,
+            "sourceTurn": source_turn_id,
+            "currentGoalReference": current_goal_reference,
+            "openQuestion": open_question,
+            "moodTags": list(mood_tags),
+            "expiresAfterTurn": expires_after_turn,
+            "sceneId": scene_id,
+        }
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, None]:
+            if npc_id not in document["identities"]:
+                return False, None
+            return self._set_working(document, npc_id, working), None
+
+        mutated, _ = self._mutate(update)
+        return mutated
+
+    def get_working(
+        self,
+        npc_id: str,
+        *,
+        scene_id: str = "",
+        current_turn: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        snapshot = self.snapshot()
+        value = snapshot["working"].get(npc_id)
+        if not isinstance(value, dict):
+            return {}
+        expired = (
+            current_turn is not None
+            and value["expiresAfterTurn"] is not None
+            and current_turn > value["expiresAfterTurn"]
+        )
+        scene_changed = bool(
+            scene_id and value["sceneId"] and scene_id != value["sceneId"]
+        )
+        if not expired and not scene_changed:
+            return copy.deepcopy(value)
+
+        def clear(document: Dict[str, Any]) -> Tuple[bool, None]:
+            return document["working"].pop(npc_id, None) is not None, None
+
+        self._mutate(clear)
+        return {}
+
+    def retrieve_evidence(
+        self,
+        subject_id: str,
+        counterparty_id: str,
+        *,
+        present_actor_ids: Iterable[str],
+        entity_ids: Iterable[str],
+        limit: int = 3,
+    ) -> list[Dict[str, Any]]:
+        edge = self.snapshot()["relationships"].get(
+            _relationship_key(subject_id, counterparty_id)
+        )
+        if not edge:
+            return []
+        relevant_ids = set(present_actor_ids) | set(entity_ids)
+
+        def rank(record: Mapping[str, Any]) -> tuple:
+            record_ids = {
+                record.get("actorId"),
+                record.get("targetId"),
+                *record.get("topicIds", []),
+            }
+            intersects = bool(relevant_ids.intersection(record_ids))
+            unresolved = (
+                bool(record.get("unresolved"))
+                or record.get("eventType") in UNRESOLVED_TYPES
+            )
+            game_day = record.get("gameDay")
+            return (
+                0 if intersects else 1,
+                0 if unresolved else 1,
+                -int(record.get("magnitude", 0)),
+                -(game_day if isinstance(game_day, int) else -1),
+                record.get("eventId", ""),
+            )
+
+        return [
+            copy.deepcopy(record)
+            for record in sorted(edge["evidence"], key=rank)[: max(0, min(limit, 3))]
+        ]
+
+    def migrate_legacy_identity(
+        self,
+        npc_id: str,
+        counterparty_id: str,
+        *,
+        game_day: Optional[int],
+    ) -> bool:
+        if self.read_only:
+            return False
+        snapshot = self.snapshot()
+        identity = snapshot["identities"].get(npc_id)
+        if not identity or identity.get("kind") != "npc":
+            return False
+        memory_dir = self.path.parent
+        matches = []
+        for candidate in sorted(memory_dir.glob("*_memories.json")):
+            if candidate.name in {"npc_agent_state.json", "memory_config.json"}:
+                continue
+            try:
+                raw = candidate.read_bytes()
+                value = json.loads(raw.decode("utf-8"))
+            except (OSError, UnicodeError, ValueError, TypeError):
+                continue
+            if not isinstance(value, dict):
+                continue
+            legacy_name = _text(value.get("npc_name"), 100)
+            if not legacy_name:
+                continue
+            matching_ids = [
+                identity_id
+                for identity_id, registered in snapshot["identities"].items()
+                if registered.get("kind") == "npc"
+                and legacy_name in _identity_names(registered)
+            ]
+            if matching_ids == [npc_id]:
+                matches.append((candidate, raw, value))
+        if len(matches) != 1:
+            return False
+        source_path, raw_bytes, legacy = matches[0]
+        source_hash = _sha256_bytes(raw_bytes)
+        migration_key = "%s|%s" % (MIGRATION_VERSION, npc_id)
+        old_migration = snapshot["migrations"].get(migration_key)
+        if old_migration and old_migration.get("sourceHash") == source_hash:
+            return False
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, None]:
+            prior = document["migrations"].get(migration_key)
+            if prior and prior.get("sourceHash") == source_hash:
+                return False, None
+            edge, _created = self._ensure_edge(
+                document, npc_id, counterparty_id, game_day
+            )
+            raw_state = legacy.get("current_emotional_state")
+            imported_state = clamp_state(
+                raw_state if isinstance(raw_state, dict) else {}
+            )
+            if not edge["evidence"] and not edge["appliedEventIds"]:
+                edge["baseline"] = imported_state
+                edge["current"] = copy.deepcopy(imported_state)
+                edge["lastDecayDay"] = game_day
+            subject = document["identities"][npc_id]
+            counterparty = document["identities"][counterparty_id]
+            imported_count = 0
+            existing_hashes = {
+                record["sourceHash"] for record in edge["evidence"] if record["sourceHash"]
+            }
+            for index, memory in enumerate(legacy.get("core_memories", [])):
+                if not isinstance(memory, dict):
+                    continue
+                memory_hash = _sha256_value(memory)
+                if memory_hash in existing_hashes:
+                    continue
+                summary = _text(
+                    memory.get("journal_excerpt")
+                    or memory.get("context")
+                    or "Imported legacy companion memory.",
+                    240,
+                ) or "Imported legacy companion memory."
+                try:
+                    velocity = float(memory.get("emotional_velocity", 0.0))
+                except (TypeError, ValueError):
+                    velocity = 0.0
+                magnitude = max(0, min(3, int(round(abs(velocity) * 3))))
+                event_id = _sha256_value([MIGRATION_VERSION, npc_id, memory_hash])
+                edge["evidence"].append(
+                    {
+                        "kind": "legacyEvidence",
+                        "eventId": event_id,
+                        "actorId": counterparty_id,
+                        "targetId": npc_id,
+                        "actor": counterparty["displayName"],
+                        "target": subject["displayName"],
+                        "eventType": None,
+                        "magnitude": magnitude,
+                        "witnessed": False,
+                        "applied": False,
+                        "delta": _neutral(),
+                        "summary": summary,
+                        "sourceTurnId": _text(memory.get("id"), 120)
+                        or "legacy-%d" % index,
+                        "promptVersion": "",
+                        "packetHash": "",
+                        "gameDay": None,
+                        "module": "",
+                        "locationId": _text(memory.get("location"), 120),
+                        "topicIds": [],
+                        "unresolved": False,
+                        "sourceHash": memory_hash,
+                    }
+                )
+                existing_hashes.add(memory_hash)
+                imported_count += 1
+            self._prune_evidence(edge)
+            behavior = legacy.get("behavioral_model")
+            behavior_hint = (
+                _canonical_json(behavior)[:500]
+                if isinstance(behavior, dict)
+                else ""
+            )
+            try:
+                relative_source = source_path.relative_to(Path.cwd()).as_posix()
+            except ValueError:
+                relative_source = source_path.as_posix()
+            document["migrations"][migration_key] = {
+                "version": MIGRATION_VERSION,
+                "npcId": npc_id,
+                "sourcePath": relative_source[:500],
+                "sourceHash": source_hash,
+                "status": "migrated",
+                "legacyBehaviorHint": behavior_hint,
+                "migratedEvidence": imported_count,
+            }
+            return True, None
+
+        mutated, _ = self._mutate(update)
+        return mutated
+
+    def _lifecycle_event(
+        self,
+        *,
+        kind: str,
+        source_turn_id: str,
+        module: str,
+        location_id: str,
+        cause: str = "",
+        departure_kind: str = "",
+        destination: str = "",
+        return_hook: str = "",
+        game_day: Optional[int] = None,
+        invited_by: str = "",
+        terms: str = "",
+        personal_objective: str = "",
+        red_lines: Iterable[str] = (),
+        compensation: str = "",
+        expected_duration: str = "",
+        prior_status: str = "unknown",
+        unresolved_obligations: Iterable[str] = (),
+    ) -> Dict[str, Any]:
+        return {
+            "kind": kind,
+            "sourceTurnId": _text(source_turn_id, 120),
+            "module": _text(module, 160),
+            "locationId": _text(location_id, 120),
+            "cause": _text(cause, 240),
+            "departureKind": _text(departure_kind, 80),
+            "destination": _text(destination, 160),
+            "returnHook": _text(return_hook, 240),
+            "gameDay": game_day if type(game_day) is int and game_day >= 0 else None,
+            "invitedBy": _text(invited_by, 100),
+            "terms": _text(terms, 240),
+            "personalObjective": _text(personal_objective, 240),
+            "redLines": _text_list(red_lines, 5, 160),
+            "compensation": _text(compensation, 160),
+            "expectedDuration": _text(expected_duration, 160),
+            "priorStatus": prior_status
+            if prior_status in {"new", "active", "inactive", "unknown"}
+            else "unknown",
+            "unresolvedObligations": _text_list(
+                unresolved_obligations, 5, 180
+            ),
+        }
+
+    def mark_joined(
+        self,
+        npc_id: str,
+        player_id: str,
+        *,
+        game_day: Optional[int],
+        module: str,
+        location_id: str,
+        source_turn_id: str,
+        lifecycle_context: Optional[Mapping[str, Any]] = None,
+    ) -> str:
+        """Initialize or recover recruitment state while retaining old affinity."""
+        context = lifecycle_context if isinstance(lifecycle_context, Mapping) else {}
+        snapshot = self.snapshot()
+        identity = snapshot["identities"].get(npc_id, {})
+        lifecycle = snapshot["lifecycle"].get(npc_id, {})
+        events = lifecycle.get("events", []) if isinstance(lifecycle, Mapping) else []
+        prior_status = (
+            "inactive"
+            if identity and not identity.get("active", True)
+            else "active"
+            if events
+            else "new"
+        )
+        kind = "rejoin" if prior_status == "inactive" else "join"
+        event = self._lifecycle_event(
+            kind=kind,
+            source_turn_id=source_turn_id,
+            module=module,
+            location_id=location_id,
+            cause=_text(context.get("reason"), 240) or "unknown",
+            game_day=game_day,
+            invited_by=_text(context.get("invitedBy"), 100) or "unknown",
+            terms=_text(context.get("terms"), 240),
+            personal_objective=_text(context.get("personalObjective"), 240),
+            red_lines=context.get("redLines", []),
+            compensation=_text(context.get("compensation"), 160),
+            expected_duration=_text(context.get("expectedDuration"), 160)
+            or "unknown",
+            prior_status=prior_status,
+        )
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, str]:
+            selected = document["identities"].get(npc_id)
+            if not selected or player_id not in document["identities"]:
+                return False, kind
+            edge, edge_created = self._ensure_edge(
+                document, npc_id, player_id, game_day
+            )
+            decayed = self._apply_decay(edge, game_day)
+            lifecycle_state = document["lifecycle"].setdefault(
+                npc_id, {"status": "active", "events": []}
+            )
+            duplicate = (
+                lifecycle_state["events"]
+                and lifecycle_state["events"][-1] == event
+                and selected.get("active") is True
+            )
+            changed = edge_created or decayed
+            if not duplicate:
+                lifecycle_state["events"] = (
+                    lifecycle_state["events"] + [event]
+                )[-64:]
+                changed = True
+            if selected.get("active") is not True:
+                selected["active"] = True
+                changed = True
+            selected["lastModule"] = _text(module, 160)
+            selected["lastLocationId"] = _text(location_id, 120)
+            lifecycle_state["status"] = "active"
+            if kind == "rejoin" and document["working"].pop(npc_id, None) is not None:
+                changed = True
+            return changed, kind
+
+        _mutated, result = self._mutate(update)
+        return result or kind
+
+    def mark_departed(
+        self,
+        npc_id: str,
+        *,
+        module: str,
+        location_id: str,
+        cause: str,
+        departure_kind: str,
+        destination: str,
+        return_hook: str,
+        source_turn_id: str = "",
+        unresolved_obligations: Iterable[str] = (),
+        game_day: Optional[int] = None,
+    ) -> bool:
+        event = self._lifecycle_event(
+            kind="depart",
+            source_turn_id=source_turn_id,
+            module=module,
+            location_id=location_id,
+            cause=cause,
+            departure_kind=departure_kind,
+            destination=destination,
+            return_hook=return_hook,
+            game_day=game_day,
+            prior_status="active",
+            unresolved_obligations=unresolved_obligations,
+        )
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, None]:
+            identity = document["identities"].get(npc_id)
+            if not identity:
+                return False, None
+            lifecycle = document["lifecycle"].setdefault(
+                npc_id, {"status": "active", "events": []}
+            )
+            if (
+                lifecycle["events"]
+                and lifecycle["events"][-1] == event
+                and not identity["active"]
+            ):
+                return False, None
+            identity["active"] = False
+            identity["lastModule"] = _text(module, 160)
+            identity["lastLocationId"] = _text(location_id, 120)
+            lifecycle["status"] = "inactive"
+            lifecycle["events"] = (lifecycle["events"] + [event])[-64:]
+            document["working"].pop(npc_id, None)
+            return True, None
+
+        mutated, _ = self._mutate(update)
+        return mutated
+
+    def mark_module_transition(
+        self,
+        *,
+        module: str,
+        location_id: str,
+        source_turn_id: str,
+        game_day: Optional[int] = None,
+    ) -> bool:
+        """Move active lifecycle context without touching affinity or profiles."""
+        event = self._lifecycle_event(
+            kind="module",
+            source_turn_id=source_turn_id,
+            module=module,
+            location_id=location_id,
+            game_day=game_day,
+            prior_status="active",
+        )
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, None]:
+            changed = False
+            for npc_id, identity in document["identities"].items():
+                if identity.get("kind") != "npc" or not identity.get("active"):
+                    continue
+                lifecycle = document["lifecycle"].setdefault(
+                    npc_id, {"status": "active", "events": []}
+                )
+                if identity.get("lastModule") != _text(module, 160):
+                    identity["lastModule"] = _text(module, 160)
+                    changed = True
+                if identity.get("lastLocationId") != _text(location_id, 120):
+                    identity["lastLocationId"] = _text(location_id, 120)
+                    changed = True
+                if not lifecycle["events"] or lifecycle["events"][-1] != event:
+                    lifecycle["events"] = (lifecycle["events"] + [event])[-64:]
+                    changed = True
+                lifecycle["status"] = "active"
+                if document["working"].pop(npc_id, None) is not None:
+                    changed = True
+            return changed, None
+
+        mutated, _ = self._mutate(update)
+        return mutated
+
+    def mark_rejoined(
+        self,
+        npc_id: str,
+        *,
+        module: str,
+        location_id: str,
+        source_turn_id: str,
+    ) -> str:
+        event = self._lifecycle_event(
+            kind="rejoin",
+            source_turn_id=source_turn_id,
+            module=module,
+            location_id=location_id,
+        )
+
+        def update(document: Dict[str, Any]) -> Tuple[bool, str]:
+            identity = document["identities"].get(npc_id)
+            if not identity:
+                return False, npc_id
+            lifecycle = document["lifecycle"].setdefault(
+                npc_id, {"status": "inactive", "events": []}
+            )
+            if (
+                lifecycle["events"]
+                and lifecycle["events"][-1] == event
+                and identity["active"]
+            ):
+                return document["working"].pop(npc_id, None) is not None, npc_id
+            identity["active"] = True
+            identity["lastModule"] = _text(module, 160)
+            identity["lastLocationId"] = _text(location_id, 120)
+            lifecycle["status"] = "active"
+            lifecycle["events"] = (lifecycle["events"] + [event])[-64:]
+            document["working"].pop(npc_id, None)
+            return True, npc_id
+
+        self._mutate(update)
+        return npc_id

--- a/core/npc/voice_context.py
+++ b/core/npc/voice_context.py
@@ -1061,10 +1061,15 @@ def run_combat_voice_stage(
         for result in batch.results:
             actor_id = actor_by_npc_id.get(result.npc_id)
             if actor_id:
-                intents[actor_id] = {
-                    "npcName": result.npc_name,
-                    "thought": result.thought,
-                }
+                entry = {"npcName": result.npc_name}
+                if result.say:
+                    entry["say"] = result.say
+                if result.do:
+                    entry["do"] = result.do
+                if result.want:
+                    entry["want"] = result.want
+                entry["thought"] = result.thought
+                intents[actor_id] = entry
         return CombatVoiceStage(batch=batch, intents=MappingProxyType(intents))
     except Exception as exc:
         _LOGGER.debug("T105 combat stage skipped: %s", type(exc).__name__)
@@ -1251,23 +1256,34 @@ def commit_accepted_ooc_voice_batch(
     return committed
 
 
+def _voice_row(result):
+    """Build one compact advisory row for the DM (null say/do/want omitted)."""
+    row = {"npcId": result.npc_id, "npcName": result.npc_name}
+    if getattr(result, "say", None):
+        row["say"] = result.say
+    if getattr(result, "do", None):
+        row["do"] = result.do
+    if getattr(result, "want", None):
+        row["want"] = result.want
+    row["thought"] = result.thought
+    return row
+
+
 def inject_voice_context(messages: list, batch: Optional[NpcVoiceBatch]):
-    """Insert vector-free private thoughts without mutating durable messages."""
+    """Insert vector-free private say/do/want/thought without mutating durable messages."""
     if batch is None or not batch.results:
         return messages
-    rows = [
-        {
-            "npcId": result.npc_id,
-            "npcName": result.npc_name,
-            "thought": result.thought,
-        }
-        for result in batch.results
-    ]
+    rows = [_voice_row(result) for result in batch.results]
     block = (
-        _PRIVATE_BLOCK_PREFIX + " Use these as "
-        "advisory characterization. The Dungeon Master owns final narration, "
-        "mechanics, and actions, and may ignore impossible advice. Do not expose "
-        "this private guidance to the player.\n"
+        _PRIVATE_BLOCK_PREFIX + " Each entry is one companion's PROPOSED "
+        "characterization for this beat: 'say' is a line they'd speak, 'do' is an "
+        "action/intent they'd take, 'want' is their current desire, 'thought' is "
+        "their private reasoning. Weave these into your narration in the NPC's "
+        "voice, but you own final narration, mechanics, and actions -- reword, "
+        "trim, or override anything that does not fit the scene or the rules, and "
+        "ignore impossible advice. Do not expose this private guidance, and never "
+        "paste 'say'/'do' verbatim without making it fit. Null fields mean the NPC "
+        "offers nothing there.\n"
         + json.dumps(rows, ensure_ascii=True, separators=(",", ":"))
     )
     copied = [dict(message) for message in messages]

--- a/core/npc/voice_context.py
+++ b/core/npc/voice_context.py
@@ -1,0 +1,1340 @@
+"""OOC packet assembly, accepted-boundary persistence, and private context."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional
+
+from core.npc.voice_packets import compose_out_of_combat_packet
+from core.npc.voice_packets import compose_combat_packet
+from core.npc.relationship_store import (
+    RelationshipStore,
+    game_day_ordinal,
+    normalize_identity_seed,
+)
+from core.npc.voice_contracts import NEGATIVE_AFFINITY_EVENT_TYPES
+from core.npc.voice_selection import (
+    SelectionFairness,
+    rank_ooc_candidates,
+    resolve_ooc_mention,
+)
+from core.npc.voice_service import NpcVoiceBatch, NpcVoiceService
+
+
+_LOGGER = logging.getLogger(__name__)
+_DEFAULT_SERVICE: Optional[NpcVoiceService] = None
+_OOC_FAIRNESS = SelectionFairness()
+_PRIVATE_BLOCK_PREFIX = "Private NPC intentions for the Dungeon Master only."
+
+
+@dataclass(frozen=True)
+class CombatVoiceStage:
+    """One request-local combat batch and its exact actor-ID T096 view."""
+
+    batch: NpcVoiceBatch
+    intents: Mapping[str, Mapping[str, str]]
+
+
+def _load_json(path: str) -> Optional[Dict[str, Any]]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _string(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _batch_id(conversation_prefix: Iterable[Any], raw_input: str) -> str:
+    payload = json.dumps(
+        {"prefix": list(conversation_prefix), "input": raw_input},
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()[:32]
+
+
+def _raw_player_text(content: Any) -> str:
+    if not isinstance(content, str):
+        return ""
+    if not content.startswith("Dungeon Master Note:"):
+        return content.strip()
+    marker = " Player: "
+    if marker not in content:
+        return ""
+    value = content.rsplit(marker, 1)[1]
+    cutoffs = [
+        index
+        for index in (
+            value.find("\n[Inventory Context:"),
+            value.find("\n[SRD CONTEXT"),
+        )
+        if index >= 0
+    ]
+    if cutoffs:
+        value = value[: min(cutoffs)]
+    return value.strip()
+
+
+def _source_turn_witnessed(user_content: Any, npc_name: str) -> bool:
+    """Read presence only from the engine-authored party field in a DM note."""
+    if not isinstance(user_content, str) or not user_content.startswith(
+        "Dungeon Master Note:"
+    ):
+        return True
+    marker = "Party NPCs: "
+    end_marker = " Party stats:"
+    start = user_content.find(marker)
+    end = user_content.find(end_marker, start + len(marker))
+    if start < 0 or end < 0:
+        return True
+    roster_text = user_content[start + len(marker) : end]
+    return "%s (" % npc_name in roster_text
+
+
+def _accepted_evidence_summary(
+    conversation_prefix: Iterable[Any], npc_name: str
+) -> tuple[str, bool, str]:
+    """Return the latest completed player/DM pair without sentiment parsing."""
+    messages = list(conversation_prefix)
+    for assistant_index in range(len(messages) - 1, -1, -1):
+        assistant = messages[assistant_index]
+        if not isinstance(assistant, dict) or assistant.get("role") != "assistant":
+            continue
+        assistant_content = assistant.get("content")
+        if not isinstance(assistant_content, str):
+            continue
+        try:
+            parsed = json.loads(assistant_content)
+            narration = parsed.get("narration", "") if isinstance(parsed, dict) else ""
+        except (TypeError, ValueError):
+            narration = assistant_content
+        narration = _string(narration)
+        if not narration:
+            continue
+        for user_index in range(assistant_index - 1, -1, -1):
+            user = messages[user_index]
+            if not isinstance(user, dict) or user.get("role") != "user":
+                continue
+            user_content = user.get("content")
+            player_text = _raw_player_text(user_content)
+            if not player_text or player_text.startswith("Error Note:"):
+                continue
+            summary = "Player: %s Result: %s" % (player_text, narration)
+            return (
+                summary[:240].rstrip(),
+                _source_turn_witnessed(user_content, npc_name),
+                player_text,
+            )
+        return "", True, ""
+    return "", True, ""
+
+
+def _accepted_legacy_combat_evidence_summary(
+    conversation_prefix: Iterable[Any],
+) -> str:
+    """Return the latest accepted legacy T045 pair, never the current turn."""
+    messages = list(conversation_prefix)
+    player_marker = "--- PLAYER ACTION ---"
+    required_marker = "--- REQUIRED RESPONSE ---"
+    for assistant_index in range(len(messages) - 1, -1, -1):
+        assistant = messages[assistant_index]
+        if not isinstance(assistant, Mapping) or assistant.get("role") != "assistant":
+            continue
+        assistant_content = assistant.get("content")
+        if not isinstance(assistant_content, str):
+            continue
+        try:
+            parsed = json.loads(assistant_content)
+            narration = parsed.get("narration", "") if isinstance(parsed, Mapping) else ""
+        except (TypeError, ValueError):
+            narration = ""
+        narration = _string(narration)
+        if not narration:
+            continue
+        for user_index in range(assistant_index - 1, -1, -1):
+            user = messages[user_index]
+            if not isinstance(user, Mapping) or user.get("role") != "user":
+                continue
+            content = user.get("content")
+            if not isinstance(content, str):
+                break
+            if player_marker not in content or required_marker not in content:
+                break
+            player_text = content.split(player_marker, 1)[1]
+            player_text = player_text.split(required_marker, 1)[0].strip()
+            if not player_text or player_text.startswith(
+                "System combat continuation:"
+            ):
+                break
+            return ("Player: %s Result: %s" % (player_text, narration))[
+                :240
+            ].rstrip()
+    return ""
+
+
+def _packet_recent_events(records: Iterable[Mapping[str, Any]]) -> list[Dict[str, Any]]:
+    result = []
+    for record in records:
+        event_type = record.get("eventType")
+        if event_type is None:
+            continue
+        magnitude = int(record.get("magnitude", 0) or 0)
+        if event_type in NEGATIVE_AFFINITY_EVENT_TYPES:
+            magnitude = -magnitude
+        result.append(
+            {
+                "actor": record.get("actor", ""),
+                "target": record.get("target", ""),
+                "eventType": event_type,
+                "magnitude": magnitude,
+                "witnessed": bool(record.get("witnessed")),
+                "summary": record.get("summary", ""),
+            }
+        )
+        if len(result) >= 3:
+            break
+    return result
+
+
+def _is_eligible_sheet(sheet: Mapping[str, Any]) -> bool:
+    unavailable = " ".join(
+        (
+            _string(sheet.get("status")),
+            _string(sheet.get("condition")),
+        )
+    ).casefold()
+    return not any(
+        marker in unavailable
+        for marker in ("dead", "defeated", "unconscious")
+    )
+
+
+def _sidecar_identity_inactive(
+    store: RelationshipStore, npc_name: str, sheet_path: str
+) -> bool:
+    """Honor an exact persisted inactive identity even if a stale roster lists it."""
+    normalized_path = normalize_identity_seed(sheet_path)
+    matches = []
+    for identity in store.snapshot().get("identities", {}).values():
+        if not isinstance(identity, Mapping) or identity.get("kind") != "npc":
+            continue
+        names = {identity.get("displayName"), *identity.get("aliases", [])}
+        if (
+            normalize_identity_seed(identity.get("sheetPath", "")) == normalized_path
+            or npc_name in names
+        ):
+            matches.append(identity)
+    return len(matches) == 1 and matches[0].get("active") is False
+
+
+def _canonical_packet_profile(
+    sheet: Mapping[str, Any], stored: Optional[Mapping[str, Any]]
+) -> Dict[str, Any]:
+    profile = {
+        "background": _string(sheet.get("background")),
+        "personality": _string(
+            sheet.get("personality_traits") or sheet.get("personality")
+        ),
+        "ideals": _string(sheet.get("ideals")),
+        "bonds": _string(sheet.get("bonds")),
+        "flaws": _string(sheet.get("flaws")),
+    }
+    if isinstance(stored, Mapping):
+        for key in (
+            "voice", "goals", "fears", "values", "preferences", "boundaries",
+            "conflictStyle", "initiativeTendency", "riskTolerance",
+            "protectionPriorities", "retreatRules", "arcSeeds",
+        ):
+            if key in stored:
+                profile[key] = copy.deepcopy(stored[key])
+    return profile
+
+
+def _utilities(sheet: Mapping[str, Any]) -> list[str]:
+    result = []
+    skills = sheet.get("skills")
+    if isinstance(skills, dict):
+        result.extend(_string(name) for name in skills if _string(name))
+    elif isinstance(skills, list):
+        result.extend(_string(name) for name in skills if _string(name))
+    languages = sheet.get("languages")
+    if isinstance(languages, list):
+        result.extend("Speaks %s" % _string(name) for name in languages if _string(name))
+    return result[:8]
+
+
+def _items(sheet: Mapping[str, Any]) -> list[str]:
+    result = []
+    equipment = sheet.get("equipment")
+    if not isinstance(equipment, list):
+        return result
+    for item in equipment:
+        if isinstance(item, dict):
+            name = _string(item.get("item_name") or item.get("name"))
+        else:
+            name = _string(item)
+        if name:
+            result.append(name)
+        if len(result) >= 8:
+            break
+    return result
+
+
+def _combat_capabilities(sheet: Mapping[str, Any]) -> list[str]:
+    """Render bounded sheet mechanics without claiming that any are legal now."""
+    result = []
+    for field in (
+        "attacksAndSpellcasting",
+        "actions",
+        "specialAbilities",
+        "classFeatures",
+        "spellcasting",
+    ):
+        value = sheet.get(field)
+        if isinstance(value, Mapping):
+            values = value.values()
+        elif isinstance(value, list):
+            values = value
+        else:
+            values = ()
+        for entry in values:
+            if isinstance(entry, Mapping):
+                name = _string(
+                    entry.get("name")
+                    or entry.get("actionName")
+                    or entry.get("spellName")
+                )
+                detail = _string(
+                    entry.get("description")
+                    or entry.get("damage")
+                    or entry.get("effect")
+                )
+                rendered = ": ".join(value for value in (name, detail) if value)
+            else:
+                rendered = _string(entry)
+            if rendered and rendered not in result:
+                result.append(rendered[:240])
+            if len(result) >= 8:
+                return result
+    return result
+
+
+def _combat_fact_text(
+    fact: Mapping[str, Any], names_by_id: Mapping[str, str]
+) -> str:
+    action = _string(fact.get("action")) or "an action"
+    event_id = _string(fact.get("eventId"))
+    event_tag = (
+        hashlib.sha256(event_id.encode("utf-8")).hexdigest()[:12]
+        if event_id
+        else ""
+    )
+    details = []
+    for target in fact.get("targets", []) if isinstance(fact.get("targets"), list) else []:
+        if not isinstance(target, Mapping):
+            continue
+        target_name = names_by_id.get(
+            _string(target.get("targetId")), _string(target.get("targetId"))
+        ) or "a combatant"
+        delta = target.get("hpDelta")
+        status = _string(target.get("statusAfter"))
+        if type(delta) is int:
+            details.append("%s HP %+d" % (target_name, delta))
+        elif status:
+            details.append("%s status %s" % (target_name, status))
+    rendered = "%s%s" % (
+        action,
+        "; " + ", ".join(details) if details else "",
+    )
+    return "event %s: %s" % (event_tag, rendered) if event_tag else rendered
+
+
+def _committed_combat_facts(encounter_data: Mapping[str, Any]) -> list[str]:
+    creatures = encounter_data.get("creatures", [])
+    names_by_id = {
+        _string(creature.get("combatantId")): _string(creature.get("name"))
+        for creature in creatures
+        if isinstance(creature, Mapping)
+    }
+    activity = (encounter_data.get("combatState") or {}).get(
+        "narrationActivity", {}
+    )
+    if not isinstance(activity, Mapping):
+        return []
+    rendered = []
+    for actor_id in sorted(activity):
+        row = activity.get(actor_id)
+        if not isinstance(row, Mapping):
+            continue
+        actor_name = names_by_id.get(actor_id, actor_id)
+        facts = row.get("recentFacts", [])
+        if not isinstance(facts, list):
+            continue
+        for fact in facts[-3:]:
+            if isinstance(fact, Mapping):
+                rendered.append(
+                    "%s committed %s." % (
+                        actor_name,
+                        _combat_fact_text(fact, names_by_id),
+                    )
+                )
+    return rendered[-8:]
+
+
+def _committed_player_evidence(
+    encounter_data: Mapping[str, Any],
+    *,
+    player: Mapping[str, Any],
+    player_id: str,
+    npc: Mapping[str, Any],
+    npc_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Return only a previously committed player fact involving this NPC."""
+    activity = (encounter_data.get("combatState") or {}).get(
+        "narrationActivity", {}
+    )
+    row = activity.get(player.get("combatantId"), {}) if isinstance(activity, Mapping) else {}
+    facts = row.get("recentFacts", []) if isinstance(row, Mapping) else []
+    names_by_id = {
+        _string(creature.get("combatantId")): _string(creature.get("name"))
+        for creature in encounter_data.get("creatures", [])
+        if isinstance(creature, Mapping)
+    }
+    for fact in reversed(facts if isinstance(facts, list) else []):
+        if not isinstance(fact, Mapping):
+            continue
+        targets = fact.get("targets", [])
+        if not any(
+            isinstance(target, Mapping)
+            and target.get("targetId") == npc.get("combatantId")
+            for target in targets if isinstance(targets, list)
+        ):
+            continue
+        return {
+            "actorId": player_id,
+            "actor": _string(player.get("name")),
+            "targetId": npc_id,
+            "target": _string(npc.get("name")),
+            "summary": (
+                "%s committed %s." % (
+                    _string(player.get("name")),
+                    _combat_fact_text(fact, names_by_id),
+                )
+            )[:240],
+            "witnessed": True,
+        }
+    return None
+
+
+def _present_actor_names(
+    tracker: Mapping[str, Any], player_name: str, npc_name: str
+) -> list[str]:
+    ordered = [player_name, npc_name]
+    for roster_npc in tracker.get("partyNPCs", []):
+        if isinstance(roster_npc, dict):
+            ordered.append(_string(roster_npc.get("name")))
+    result = []
+    for name in ordered:
+        if name and name not in result:
+            result.append(name)
+        if len(result) >= 12:
+            break
+    return result
+
+
+def build_ooc_packet_for_turn(
+    *,
+    party_tracker_data: Mapping[str, Any],
+    player_name: str,
+    raw_input: str,
+    location_data: Optional[Mapping[str, Any]],
+    conversation_prefix: Iterable[Any],
+    path_manager: Any,
+    json_loader: Callable[[str], Optional[Dict[str, Any]]] = _load_json,
+    relationship_store: Optional[RelationshipStore] = None,
+    _selected_candidate: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Compose one eligible packet; raw player text is never prose-gated."""
+    roster = party_tracker_data.get("partyNPCs", [])
+    if not isinstance(roster, list):
+        roster = []
+    _mentioned_npc, ambiguous_mention = resolve_ooc_mention(roster, raw_input)
+    store = relationship_store or RelationshipStore()
+    selected = None
+    selected_sheet = None
+    selected_path = None
+    candidate_order = (
+        [dict(_selected_candidate)]
+        if isinstance(_selected_candidate, Mapping)
+        else rank_ooc_candidates(roster, raw_input)
+    )
+    for candidate in candidate_order:
+        name = _string(candidate.get("name"))
+        if not name:
+            continue
+        path = path_manager.get_character_path(name)
+        sheet = json_loader(path)
+        if not isinstance(sheet, dict) or not _is_eligible_sheet(sheet):
+            continue
+        sheet_name = _string(sheet.get("name")) or name
+        if _sidecar_identity_inactive(store, sheet_name, path):
+            continue
+        selected = candidate
+        selected_sheet = sheet
+        selected_path = path
+        break
+    if selected is None or selected_sheet is None or selected_path is None:
+        raise ValueError("no eligible active party NPC")
+
+    npc_name = _string(selected_sheet.get("name")) or _string(selected.get("name"))
+    role = _string(selected.get("role")) or "party companion"
+    player_path = path_manager.get_character_path(player_name)
+    world = party_tracker_data.get("worldConditions", {})
+    if not isinstance(world, dict):
+        world = {}
+    location = location_data if isinstance(location_data, dict) else {}
+    location_name = (
+        _string(world.get("currentLocation"))
+        or _string(location.get("name"))
+        or "Unknown location"
+    )
+    location_id = _string(world.get("currentLocationId")) or "unknown"
+    module = _string(party_tracker_data.get("module")) or "Unknown module"
+    current_game_day = game_day_ordinal(world)
+    npc_id = store.ensure_identity(
+        kind="npc",
+        display_name=npc_name,
+        sheet_path=selected_path,
+        module=module,
+        location_id=location_id,
+        active=None,
+    )
+    player_id = store.ensure_identity(
+        kind="player",
+        display_name=player_name,
+        sheet_path=player_path,
+        module=module,
+        location_id=location_id,
+    )
+    store.migrate_legacy_identity(
+        npc_id,
+        player_id,
+        game_day=current_game_day,
+    )
+    relationship_state = store.get_relationship(
+        npc_id,
+        player_id,
+        game_day=current_game_day,
+    )
+    retrieved_evidence = store.retrieve_evidence(
+        npc_id,
+        player_id,
+        present_actor_ids=(npc_id, player_id),
+        entity_ids=(),
+    )
+    scene_id = "%s|%s" % (module, location_id)
+    stored_working = store.get_working(npc_id, scene_id=scene_id)
+    accepted_summary, accepted_witnessed, accepted_player_text = (
+        _accepted_evidence_summary(conversation_prefix, npc_name)
+    )
+    _accepted_mention, accepted_mention_ambiguous = resolve_ooc_mention(
+        roster, accepted_player_text
+    )
+    beat_evidence = None
+    accepted_matches_selected = (
+        _accepted_mention is None
+        or _string(_accepted_mention.get("name")) == _string(selected.get("name"))
+    )
+    if (
+        accepted_summary
+        and not ambiguous_mention
+        and not accepted_mention_ambiguous
+        and accepted_matches_selected
+    ):
+        beat_evidence = {
+            "actorId": player_id,
+            "actor": player_name,
+            "targetId": npc_id,
+            "target": npc_name,
+            "summary": accepted_summary,
+            "witnessed": accepted_witnessed,
+        }
+
+    stored_profile = store.get_profile(npc_id)
+    profile = _canonical_packet_profile(selected_sheet, stored_profile)
+    structured_goals = (
+        list(profile.get("goals", [])) if isinstance(profile.get("goals"), list) else []
+    )
+    arc_seeds = (
+        list(profile.get("arcSeeds", []))
+        if isinstance(profile.get("arcSeeds"), list)
+        else []
+    )
+    goals = list(dict.fromkeys(
+        structured_goals
+        + arc_seeds[:1]
+        + [profile["bonds"], profile["ideals"], role]
+    ))
+    goals = [goal for goal in goals if goal]
+    location_description = _string(location.get("description"))
+    social_context = location_description or (
+        "%s is present with the party at %s." % (npc_name, location_name)
+    )
+    packet = compose_out_of_combat_packet(
+        beat={
+            "id": _batch_id(conversation_prefix, raw_input),
+            "summary": raw_input,
+            # Only the prior accepted player/DM pair is committed evidence.
+            # The current declaration remains summary/context only.
+            "relationshipEvidence": beat_evidence,
+        },
+        npc={
+            "id": npc_id,
+            "name": npc_name,
+            "role": role,
+            "profile": profile,
+        },
+        relationship={
+            "counterpartyId": player_id,
+            "counterpartyName": player_name,
+            "state": relationship_state["current"],
+            "recentEvents": _packet_recent_events(retrieved_evidence),
+        },
+        scene={
+            "module": module,
+            "locationId": location_id,
+            "location": location_name,
+            "presentActors": _present_actor_names(
+                party_tracker_data, player_name, npc_name
+            ),
+            "stakes": raw_input,
+            "recentEvents": [],
+        },
+        working={
+            "currentGoal": goals[0] if goals else "",
+            "priorPrivateIntent": stored_working.get("currentPrivateIntent", ""),
+            "openQuestion": stored_working.get("openQuestion", ""),
+            "moodTags": stored_working.get("moodTags", []),
+            "expiresAfterTurn": stored_working.get("expiresAfterTurn"),
+        },
+        utilities=_utilities(selected_sheet),
+        items=_items(selected_sheet),
+        social_context=social_context,
+        current_goals=goals[:5],
+    )
+    return packet
+
+
+def build_ooc_packets_for_turn(
+    *,
+    party_tracker_data: Mapping[str, Any],
+    player_name: str,
+    raw_input: str,
+    location_data: Optional[Mapping[str, Any]],
+    conversation_prefix: Iterable[Any],
+    path_manager: Any,
+    json_loader: Callable[[str], Optional[Dict[str, Any]]] = _load_json,
+    relationship_store: Optional[RelationshipStore] = None,
+    fairness: Optional[SelectionFairness] = None,
+    limit: int = 4,
+) -> tuple[Dict[str, Any], ...]:
+    """Compose and deterministically rank up to four eligible OOC packets."""
+    roster = party_tracker_data.get("partyNPCs", [])
+    if not isinstance(roster, list):
+        return ()
+    prefix = list(conversation_prefix)
+    store = relationship_store or RelationshipStore()
+    packets_by_id: Dict[str, Dict[str, Any]] = {}
+    ranked_inputs = []
+    evidence_npc_ids = set()
+    for candidate in roster:
+        if not isinstance(candidate, Mapping):
+            continue
+        try:
+            packet = build_ooc_packet_for_turn(
+                party_tracker_data=party_tracker_data,
+                player_name=player_name,
+                raw_input=raw_input,
+                location_data=location_data,
+                conversation_prefix=prefix,
+                path_manager=path_manager,
+                json_loader=json_loader,
+                relationship_store=store,
+                _selected_candidate=candidate,
+            )
+        except Exception:
+            continue
+        npc_id = packet["npc"]["id"]
+        packets_by_id[npc_id] = packet
+        ranked_inputs.append(
+            {
+                "name": _string(candidate.get("name")) or packet["npc"]["name"],
+                "role": candidate.get("role", ""),
+                "npcId": npc_id,
+            }
+        )
+        if packet["beat"]["relationshipEvidence"] is not None:
+            evidence_npc_ids.add(npc_id)
+
+    ranked = rank_ooc_candidates(
+        ranked_inputs,
+        raw_input,
+        evidence_npc_ids=evidence_npc_ids,
+        fairness=fairness or _OOC_FAIRNESS,
+        limit=min(4, max(0, int(limit))),
+    )
+    return tuple(packets_by_id[candidate["npcId"]] for candidate in ranked)
+
+
+def build_combat_packets_for_window(
+    *,
+    encounter_data: Mapping[str, Any],
+    actor_ids: Iterable[str],
+    character_paths: Mapping[str, str],
+    context_sheets: Mapping[str, Mapping[str, Any]],
+    party_tracker_data: Mapping[str, Any],
+    location_info: Optional[Mapping[str, Any]],
+    player_input: str,
+    legacy_conversation_prefix: Optional[Iterable[Any]] = None,
+    relationship_store: Optional[RelationshipStore] = None,
+) -> tuple[tuple[str, Dict[str, Any]], ...]:
+    """Compose packets for exact pending-window party NPC combatant IDs only."""
+    actor_window = list(dict.fromkeys(_string(value) for value in actor_ids if _string(value)))
+    if not actor_window:
+        return ()
+    creatures = [
+        creature
+        for creature in encounter_data.get("creatures", [])
+        if isinstance(creature, Mapping)
+    ]
+    creatures_by_id = {
+        _string(creature.get("combatantId")): creature for creature in creatures
+    }
+    player = next(
+        (creature for creature in creatures if creature.get("type") == "player"),
+        None,
+    )
+    if player is None:
+        return ()
+    roster = party_tracker_data.get("partyNPCs", [])
+    roster_by_name = {
+        _string(row.get("name")): row
+        for row in roster
+        if isinstance(row, Mapping) and _string(row.get("name"))
+    } if isinstance(roster, list) else {}
+    if not roster_by_name:
+        return ()
+
+    store = relationship_store or RelationshipStore()
+    legacy_prefix = (
+        list(legacy_conversation_prefix)
+        if legacy_conversation_prefix is not None
+        else None
+    )
+    world = party_tracker_data.get("worldConditions", {})
+    if not isinstance(world, Mapping):
+        world = {}
+    module = _string(party_tracker_data.get("module")) or "Unknown module"
+    location = location_info if isinstance(location_info, Mapping) else {}
+    location_id = _string(world.get("currentLocationId")) or "unknown"
+    location_name = (
+        _string(world.get("currentLocation"))
+        or _string(location.get("name"))
+        or "Unknown location"
+    )
+    game_day = game_day_ordinal(world)
+    player_name = _string(player.get("name"))
+    player_path = character_paths.get(player_name, player_name)
+    player_id = store.ensure_identity(
+        kind="player",
+        display_name=player_name,
+        sheet_path=str(player_path),
+        module=module,
+        location_id=location_id,
+    )
+    stable_present_ids = [player_id]
+    committed_facts = _committed_combat_facts(encounter_data)
+    state = encounter_data.get("combatState", {})
+    revision = state.get("revision", 0) if isinstance(state, Mapping) else 0
+    round_number = state.get("round", 1) if isinstance(state, Mapping) else 1
+    scene_id = "%s|%s|combat" % (module, location_id)
+    present_names = [
+        _string(creature.get("name"))
+        for creature in creatures
+        if _string(creature.get("name"))
+        and _string(creature.get("status") or "alive").casefold()
+        not in {"dead", "defeated"}
+    ][:12]
+    threats = [
+        {
+            "name": _string(creature.get("name")) or "Unknown threat",
+            "position": _string(creature.get("position")) or "in the encounter",
+            "intent": _string((creature.get("actions") or {}).get("actionType"))
+            if isinstance(creature.get("actions"), Mapping)
+            else "",
+        }
+        for creature in creatures
+        if creature.get("type") == "enemy" or creature.get("faction") == "hostile"
+    ]
+    for threat in threats:
+        if not threat["intent"]:
+            threat["intent"] = "oppose the party"
+
+    packets = []
+    for actor_id in actor_window:
+        creature = creatures_by_id.get(actor_id)
+        if (
+            not isinstance(creature, Mapping)
+            or creature.get("type") != "npc"
+            or _string(creature.get("name")) not in roster_by_name
+        ):
+            continue
+        npc_name = _string(creature.get("name"))
+        sheet = context_sheets.get(npc_name)
+        sheet_path = character_paths.get(npc_name)
+        if not isinstance(sheet, Mapping) or not sheet_path:
+            continue
+        if _sidecar_identity_inactive(store, npc_name, str(sheet_path)):
+            continue
+        npc_id = store.ensure_identity(
+            kind="npc",
+            display_name=npc_name,
+            sheet_path=str(sheet_path),
+            module=module,
+            location_id=location_id,
+            active=None,
+        )
+        store.migrate_legacy_identity(npc_id, player_id, game_day=game_day)
+        relationship = store.get_relationship(npc_id, player_id, game_day=game_day)
+        retrieved = store.retrieve_evidence(
+            npc_id,
+            player_id,
+            present_actor_ids=tuple(stable_present_ids + [npc_id]),
+            entity_ids=(),
+        )
+        working = store.get_working(
+            npc_id,
+            scene_id=scene_id,
+            current_turn=round_number if type(round_number) is int else None,
+        )
+        evidence = _committed_player_evidence(
+            encounter_data,
+            player=player,
+            player_id=player_id,
+            npc=creature,
+            npc_id=npc_id,
+        )
+        if evidence is None and legacy_prefix is not None:
+            accepted_summary = _accepted_legacy_combat_evidence_summary(
+                legacy_prefix
+            )
+            if accepted_summary:
+                evidence = {
+                    "actorId": player_id,
+                    "actor": player_name,
+                    "targetId": npc_id,
+                    "target": npc_name,
+                    "summary": accepted_summary,
+                    "witnessed": True,
+                }
+        hp_current = creature.get("currentHitPoints", sheet.get("hitPoints", 1))
+        hp_maximum = creature.get("maxHitPoints", sheet.get("maxHitPoints", hp_current))
+        hp_current = max(0, int(hp_current)) if isinstance(hp_current, (int, float)) else 0
+        hp_maximum = max(1, int(hp_maximum)) if isinstance(hp_maximum, (int, float)) else 1
+        armor = creature.get("armorClass", sheet.get("armorClass", 10))
+        armor = max(1, min(40, int(armor))) if isinstance(armor, (int, float)) else 10
+        conditions = creature.get("conditions", sheet.get("condition_affected", []))
+        conditions = conditions if isinstance(conditions, list) else []
+        role = _string(roster_by_name[npc_name].get("role")) or "party companion"
+        profile = _canonical_packet_profile(sheet, store.get_profile(npc_id))
+        structured_goals = (
+            list(profile.get("goals", []))
+            if isinstance(profile.get("goals"), list)
+            else []
+        )
+        arc_seeds = (
+            list(profile.get("arcSeeds", []))
+            if isinstance(profile.get("arcSeeds"), list)
+            else []
+        )
+        goals = list(dict.fromkeys(
+            structured_goals
+            + arc_seeds[:1]
+            + [profile["bonds"], profile["ideals"], role]
+        ))
+        goals = [value for value in goals if value]
+        allies = [
+            "%s: %s" % (
+                _string(other.get("name")),
+                _string(other.get("status") or "alive"),
+            )
+            for other in creatures
+            if other.get("combatantId") != actor_id
+            and other.get("type") in {"player", "npc"}
+            and _string(other.get("name"))
+        ][:8]
+        stakes = " ".join(
+            value
+            for value in (
+                _string(encounter_data.get("encounterSummary")),
+                _string(player_input),
+            )
+            if value
+        ) or "Resolve the current combat window."
+        beat_id = "combat:%s:r%s:v%s:%s" % (
+            _string(encounter_data.get("encounterId")) or "unknown",
+            round_number,
+            revision,
+            ",".join(actor_window),
+        )
+        packet = compose_combat_packet(
+            beat={
+                "id": beat_id[:120],
+                "summary": stakes,
+                "relationshipEvidence": evidence,
+            },
+            npc={"id": npc_id, "name": npc_name, "role": role, "profile": profile},
+            relationship={
+                "counterpartyId": player_id,
+                "counterpartyName": player_name,
+                "state": relationship["current"],
+                "recentEvents": _packet_recent_events(retrieved),
+            },
+            scene={
+                "module": module,
+                "locationId": location_id,
+                "location": location_name,
+                "presentActors": present_names,
+                "stakes": stakes,
+                "recentEvents": committed_facts[-6:],
+            },
+            working={
+                "currentGoal": goals[0] if goals else "",
+                "priorPrivateIntent": working.get("currentPrivateIntent", ""),
+                "openQuestion": working.get("openQuestion", ""),
+                "moodTags": working.get("moodTags", []),
+                "expiresAfterTurn": working.get("expiresAfterTurn"),
+            },
+            status={
+                "hitPoints": {"current": min(hp_current, hp_maximum), "maximum": hp_maximum},
+                "armorClass": armor,
+                "conditions": conditions,
+                "position": _string(creature.get("position")) or "in the encounter",
+            },
+            capabilities=_combat_capabilities(sheet),
+            allies=allies,
+            threats=threats,
+            last_round_events=committed_facts,
+        )
+        packets.append((actor_id, packet))
+    return tuple(packets)
+
+
+def legacy_actor_ids_for_turn_window(
+    encounter_data: Mapping[str, Any],
+    turn_window: Optional[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    """Resolve a calculated legacy name/ID window to exact combatant IDs."""
+    if not isinstance(turn_window, Mapping):
+        return ()
+    requested = turn_window.get("turn_window")
+    if not isinstance(requested, list):
+        return ()
+    creatures = [
+        creature
+        for creature in encounter_data.get("creatures", [])
+        if isinstance(creature, Mapping)
+    ]
+    by_id = {
+        _string(creature.get("combatantId")): creature
+        for creature in creatures
+        if _string(creature.get("combatantId"))
+    }
+    ids_by_name: Dict[str, list[str]] = {}
+    for creature in creatures:
+        name = _string(creature.get("name"))
+        actor_id = _string(creature.get("combatantId"))
+        if name and actor_id:
+            ids_by_name.setdefault(name, []).append(actor_id)
+
+    actor_ids = []
+    for entry in requested:
+        if isinstance(entry, Mapping):
+            requested_id = _string(entry.get("combatantId"))
+            requested_name = _string(entry.get("name"))
+        else:
+            requested_id = _string(entry)
+            requested_name = requested_id
+        actor_id = requested_id if requested_id in by_id else ""
+        if not actor_id:
+            matches = ids_by_name.get(requested_name, [])
+            if len(matches) == 1:
+                actor_id = matches[0]
+        if actor_id and actor_id not in actor_ids:
+            actor_ids.append(actor_id)
+    return tuple(actor_ids)
+
+
+def _empty_combat_stage() -> CombatVoiceStage:
+    return CombatVoiceStage(
+        batch=NpcVoiceBatch(batch_id="", results=()),
+        intents=MappingProxyType({}),
+    )
+
+
+def run_combat_voice_stage(
+    *,
+    recovery_action_name: str,
+    encounter_data: Mapping[str, Any],
+    actor_ids: Iterable[str],
+    character_paths: Mapping[str, str],
+    context_sheets: Mapping[str, Mapping[str, Any]],
+    party_tracker_data: Mapping[str, Any],
+    location_info: Optional[Mapping[str, Any]],
+    player_input: str,
+    legacy_conversation_prefix: Optional[Iterable[Any]] = None,
+    service: Optional[NpcVoiceService] = None,
+    relationship_store: Optional[RelationshipStore] = None,
+) -> CombatVoiceStage:
+    """Run T105 for a fresh/regenerated T096 window and contain all failure."""
+    if recovery_action_name not in {"continue", "regenerate_intent"}:
+        return _empty_combat_stage()
+    try:
+        packet_rows = build_combat_packets_for_window(
+            encounter_data=encounter_data,
+            actor_ids=actor_ids,
+            character_paths=character_paths,
+            context_sheets=context_sheets,
+            party_tracker_data=party_tracker_data,
+            location_info=location_info,
+            player_input=player_input,
+            legacy_conversation_prefix=legacy_conversation_prefix,
+            relationship_store=relationship_store,
+        )
+        if not packet_rows:
+            return _empty_combat_stage()
+        batch = (service or _default_service()).think_batch_best_effort(
+            [packet for _actor_id, packet in packet_rows]
+        )
+        packets_by_npc_id = {
+            packet["npc"]["id"]: packet for _actor_id, packet in packet_rows
+        }
+        batch = replace(
+            batch,
+            results=tuple(
+                replace(
+                    result,
+                    relationship_evidence_id=(
+                        "combat-evidence:%s" % hashlib.sha256(
+                            json.dumps(
+                                packets_by_npc_id[result.npc_id]["beat"][
+                                    "relationshipEvidence"
+                                ],
+                                ensure_ascii=True,
+                                sort_keys=True,
+                                separators=(",", ":"),
+                            ).encode("ascii")
+                        ).hexdigest()
+                        if packets_by_npc_id.get(result.npc_id, {}).get("beat", {}).get(
+                            "relationshipEvidence"
+                        ) is not None
+                        else ""
+                    ),
+                )
+                for result in batch.results
+            ),
+        )
+        actor_by_npc_id = {
+            packet["npc"]["id"]: actor_id for actor_id, packet in packet_rows
+        }
+        intents = {}
+        for result in batch.results:
+            actor_id = actor_by_npc_id.get(result.npc_id)
+            if actor_id:
+                intents[actor_id] = {
+                    "npcName": result.npc_name,
+                    "thought": result.thought,
+                }
+        return CombatVoiceStage(batch=batch, intents=MappingProxyType(intents))
+    except Exception as exc:
+        _LOGGER.debug("T105 combat stage skipped: %s", type(exc).__name__)
+        return _empty_combat_stage()
+
+
+def run_legacy_combat_voice_stage(
+    *,
+    encounter_data: Mapping[str, Any],
+    turn_window: Optional[Mapping[str, Any]],
+    character_paths: Mapping[str, str],
+    context_sheets: Mapping[str, Mapping[str, Any]],
+    party_tracker_data: Mapping[str, Any],
+    location_info: Optional[Mapping[str, Any]],
+    player_input: str,
+    conversation_prefix: Iterable[Any],
+    service: Optional[NpcVoiceService] = None,
+    relationship_store: Optional[RelationshipStore] = None,
+) -> CombatVoiceStage:
+    """Run one fail-open T105 batch for the calculated legacy T045 window."""
+    actor_ids = legacy_actor_ids_for_turn_window(encounter_data, turn_window)
+    return run_combat_voice_stage(
+        recovery_action_name="continue",
+        encounter_data=encounter_data,
+        actor_ids=actor_ids,
+        character_paths=character_paths,
+        context_sheets=context_sheets,
+        party_tracker_data=party_tracker_data,
+        location_info=location_info,
+        player_input=player_input,
+        legacy_conversation_prefix=conversation_prefix,
+        service=service,
+        relationship_store=relationship_store,
+    )
+
+
+def commit_accepted_combat_voice_batch(
+    batch: Optional[NpcVoiceBatch],
+    party_tracker_data: Mapping[str, Any],
+    *,
+    relationship_store: Optional[RelationshipStore] = None,
+) -> int:
+    """Apply only validated prior-commit evidence, idempotently and fail-open."""
+    return commit_accepted_ooc_voice_batch(
+        batch,
+        party_tracker_data,
+        relationship_store=relationship_store,
+    )
+
+
+def _default_service() -> NpcVoiceService:
+    global _DEFAULT_SERVICE
+    if _DEFAULT_SERVICE is None:
+        _DEFAULT_SERVICE = NpcVoiceService()
+    return _DEFAULT_SERVICE
+
+
+def run_ooc_voice_stage(
+    *,
+    party_tracker_data: Mapping[str, Any],
+    player_name: str,
+    raw_input: str,
+    location_data: Optional[Mapping[str, Any]],
+    conversation_prefix: Iterable[Any],
+    path_manager: Any,
+    service: Optional[NpcVoiceService] = None,
+    relationship_store: Optional[RelationshipStore] = None,
+    fairness: Optional[SelectionFairness] = None,
+) -> NpcVoiceBatch:
+    """Run one bounded Phase 3 T105 batch and contain every failure."""
+    try:
+        selection = fairness or _OOC_FAIRNESS
+        packets = build_ooc_packets_for_turn(
+            party_tracker_data=party_tracker_data,
+            player_name=player_name,
+            raw_input=raw_input,
+            location_data=location_data,
+            conversation_prefix=conversation_prefix,
+            path_manager=path_manager,
+            relationship_store=relationship_store,
+            fairness=selection,
+        )
+        batch = (service or _default_service()).think_batch_best_effort(packets)
+        selection.record_merged(result.npc_id for result in batch.results)
+        return batch
+    except Exception as exc:
+        _LOGGER.debug("T105 OOC stage skipped: %s", type(exc).__name__)
+        return NpcVoiceBatch(batch_id="", results=())
+
+
+def commit_accepted_ooc_voice_batch(
+    batch: Optional[NpcVoiceBatch],
+    party_tracker_data: Mapping[str, Any],
+    *,
+    relationship_store: Optional[RelationshipStore] = None,
+) -> int:
+    """Commit a staged batch only after T067 validation accepts its candidate."""
+    if batch is None or not batch.results:
+        return 0
+    store = relationship_store or RelationshipStore()
+    world = party_tracker_data.get("worldConditions", {})
+    game_day = game_day_ordinal(world if isinstance(world, Mapping) else {})
+    committed = 0
+    for result in batch.results:
+        try:
+            if (
+                batch.generation_token
+                and result.generation_token != batch.generation_token
+            ):
+                if batch.telemetry is not None:
+                    batch.telemetry.record_disposition(
+                        "commit",
+                        "generation_rejected",
+                        batch_id=batch.batch_id,
+                        npc_id=result.npc_id,
+                    )
+                continue
+            working = {
+                "currentPrivateIntent": result.thought,
+                "sourceTurn": result.source_turn_id or batch.batch_id,
+                "currentGoalReference": result.current_goal_reference,
+                "openQuestion": result.open_question,
+                "moodTags": list(result.mood_tags),
+                "expiresAfterTurn": result.expires_after_turn,
+                "sceneId": result.scene_id,
+            }
+            if result.affinity_event is not None:
+                application = store.apply_event(
+                    subject_id=result.npc_id,
+                    counterparty_id=result.counterparty_id,
+                    event=result.affinity_event,
+                    source_turn_id=(
+                        result.relationship_evidence_id
+                        or result.source_turn_id
+                        or batch.batch_id
+                    ),
+                    evidence_summary=result.relationship_evidence_summary,
+                    game_day=game_day,
+                    module=result.module,
+                    location_id=result.location_id,
+                    packet_hash=result.packet_hash,
+                    working=working,
+                )
+                committed += int(application.mutated)
+                if batch.telemetry is not None:
+                    batch.telemetry.record_disposition(
+                        "commit",
+                        "duplicate" if application.duplicate else (
+                            "applied" if application.mutated else "not_applied"
+                        ),
+                        batch_id=batch.batch_id,
+                        npc_id=result.npc_id,
+                    )
+            else:
+                working_mutated = store.update_working(
+                    result.npc_id,
+                    source_turn_id=result.source_turn_id or batch.batch_id,
+                    thought=result.thought,
+                    current_goal_reference=result.current_goal_reference,
+                    open_question=result.open_question,
+                    mood_tags=result.mood_tags,
+                    expires_after_turn=result.expires_after_turn,
+                    scene_id=result.scene_id,
+                )
+                committed += int(working_mutated)
+                if batch.telemetry is not None:
+                    batch.telemetry.record_disposition(
+                        "commit",
+                        "working_updated" if working_mutated else "duplicate",
+                        batch_id=batch.batch_id,
+                        npc_id=result.npc_id,
+                    )
+        except Exception as exc:
+            if batch.telemetry is not None:
+                batch.telemetry.record_disposition(
+                    "commit",
+                    "failure",
+                    batch_id=batch.batch_id,
+                    npc_id=result.npc_id,
+                )
+            _LOGGER.debug(
+                "T105 accepted event skipped: %s", type(exc).__name__
+            )
+    return committed
+
+
+def inject_voice_context(messages: list, batch: Optional[NpcVoiceBatch]):
+    """Insert vector-free private thoughts without mutating durable messages."""
+    if batch is None or not batch.results:
+        return messages
+    rows = [
+        {
+            "npcId": result.npc_id,
+            "npcName": result.npc_name,
+            "thought": result.thought,
+        }
+        for result in batch.results
+    ]
+    block = (
+        _PRIVATE_BLOCK_PREFIX + " Use these as "
+        "advisory characterization. The Dungeon Master owns final narration, "
+        "mechanics, and actions, and may ignore impossible advice. Do not expose "
+        "this private guidance to the player.\n"
+        + json.dumps(rows, ensure_ascii=True, separators=(",", ":"))
+    )
+    copied = [dict(message) for message in messages]
+    insert_at = len(copied)
+    for index in range(len(copied) - 1, -1, -1):
+        if copied[index].get("role") == "user":
+            insert_at = index
+            break
+    copied.insert(insert_at, {"role": "system", "content": block})
+    return copied
+
+
+def inject_legacy_combat_voice_context(
+    messages: list,
+    batch: Optional[NpcVoiceBatch],
+):
+    """Insert the OOC-format block before the final combat-state message."""
+    if batch is None or not batch.results:
+        return messages
+    copied = inject_voice_context(messages, batch)
+    private_index = next(
+        (
+            index
+            for index, message in enumerate(copied)
+            if message.get("role") == "system"
+            and isinstance(message.get("content"), str)
+            and message["content"].startswith(_PRIVATE_BLOCK_PREFIX)
+        ),
+        None,
+    )
+    if private_index is None:
+        return messages
+    private_message = copied.pop(private_index)
+    insert_at = next(
+        (
+            index
+            for index in range(len(copied) - 1, -1, -1)
+            if copied[index].get("role") == "user"
+            and isinstance(copied[index].get("content"), str)
+            and "--- PLAYER ACTION ---" in copied[index]["content"]
+        ),
+        None,
+    )
+    if insert_at is None:
+        return messages
+    copied.insert(insert_at, private_message)
+    return copied
+
+
+def redact_voice_context(messages: list):
+    """Remove private voice text from ordinary always-on diagnostics."""
+    if not any(
+        isinstance(message, dict)
+        and message.get("role") == "system"
+        and isinstance(message.get("content"), str)
+        and message["content"].startswith(_PRIVATE_BLOCK_PREFIX)
+        for message in messages
+    ):
+        return messages
+    redacted = []
+    for message in messages:
+        copied = dict(message)
+        if (
+            copied.get("role") == "system"
+            and isinstance(copied.get("content"), str)
+            and copied["content"].startswith(_PRIVATE_BLOCK_PREFIX)
+        ):
+            copied["content"] = "Private NPC guidance: [redacted]"
+        redacted.append(copied)
+    return redacted

--- a/core/npc/voice_contracts.py
+++ b/core/npc/voice_contracts.py
@@ -1,0 +1,555 @@
+"""Strict contracts for private NPC voice requests and responses."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from typing import Any, Dict, Iterable, Mapping
+
+from jsonschema import Draft202012Validator
+
+
+TASK_ID = "T105"
+PACKET_VERSION = "npc-voice-packet/v1"
+PROMPT_VERSION = "npc-voice-prompt/v2"
+RESPONSE_SCHEMA_VERSION = "npc-voice-response/v1"
+MAX_THOUGHT_WORDS = 80
+
+AFFINITY_EVENT_TYPES = (
+    "abandon",
+    "betray",
+    "deceive",
+    "disrespect",
+    "give",
+    "harm",
+    "heal",
+    "honor",
+    "protect",
+    "rescue",
+    "share",
+    "support",
+    "threaten",
+    "trust",
+)
+NEGATIVE_AFFINITY_EVENT_TYPES = frozenset(
+    {"abandon", "betray", "deceive", "disrespect", "harm", "threaten"}
+)
+POSITIVE_AFFINITY_EVENT_TYPES = (
+    frozenset(AFFINITY_EVENT_TYPES) - NEGATIVE_AFFINITY_EVENT_TYPES
+)
+
+
+class ThoughtContractError(ValueError):
+    """A packet or model response violated the T105 contract."""
+
+
+def strict_object(
+    properties: Dict[str, Any], required: Iterable[str]
+) -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+AFFINITY_EVENT_SCHEMA = strict_object(
+    {
+        "actor": {"type": "string", "minLength": 1, "maxLength": 100},
+        "target": {"type": "string", "minLength": 1, "maxLength": 100},
+        "eventType": {"type": "string", "enum": list(AFFINITY_EVENT_TYPES)},
+        "magnitude": {"type": "integer", "enum": [-3, -2, -1, 1, 2, 3]},
+        "witnessed": {"type": "boolean"},
+    },
+    ("actor", "target", "eventType", "magnitude", "witnessed"),
+)
+
+THOUGHT_RESPONSE_SCHEMA = strict_object(
+    {
+        "thought": {"type": "string", "minLength": 1, "maxLength": 640},
+        "affinityEvent": {
+            "anyOf": [
+                {"type": "null"},
+                AFFINITY_EVENT_SCHEMA,
+            ]
+        },
+    },
+    ("thought", "affinityEvent"),
+)
+
+PROFILE_SCHEMA = strict_object(
+    {
+        "background": {"type": "string", "maxLength": 800},
+        "personality": {"type": "string", "maxLength": 800},
+        "ideals": {"type": "string", "maxLength": 400},
+        "bonds": {"type": "string", "maxLength": 400},
+        "flaws": {"type": "string", "maxLength": 400},
+    },
+    ("background", "personality", "ideals", "bonds", "flaws"),
+)
+
+STRUCTURED_PROFILE_SCHEMA = strict_object(
+    {
+        "voice": strict_object(
+            {
+                "cadence": {"type": "string", "maxLength": 120},
+                "diction": {"type": "string", "maxLength": 120},
+                "taboos": {
+                    "type": "array",
+                    "maxItems": 3,
+                    "uniqueItems": True,
+                    "items": {"type": "string", "minLength": 1, "maxLength": 80},
+                },
+            },
+            ("cadence", "diction", "taboos"),
+        ),
+        "goals": {
+            "type": "array", "minItems": 1, "maxItems": 3, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 180},
+        },
+        "fears": {
+            "type": "array", "maxItems": 3, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 180},
+        },
+        "values": {
+            "type": "array", "minItems": 1, "maxItems": 5, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 120},
+        },
+        "preferences": {
+            "type": "array", "maxItems": 5, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 120},
+        },
+        "boundaries": {
+            "type": "array", "maxItems": 5, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 160},
+        },
+        "conflictStyle": {"type": "string", "maxLength": 160},
+        "initiativeTendency": {
+            "type": "string",
+            "enum": ["reserved", "balanced", "proactive"]
+        },
+        "riskTolerance": {
+            "type": "string", "enum": ["cautious", "measured", "bold"]
+        },
+        "protectionPriorities": {
+            "type": "array", "maxItems": 3, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 120},
+        },
+        "retreatRules": {
+            "type": "array", "maxItems": 3, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 160},
+        },
+        "arcSeeds": {
+            "type": "array", "maxItems": 2, "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1, "maxLength": 180},
+        },
+    },
+    (
+        "voice", "goals", "fears", "values", "preferences", "boundaries",
+        "conflictStyle", "initiativeTendency", "riskTolerance",
+        "protectionPriorities", "retreatRules", "arcSeeds",
+    ),
+)
+
+# Phase 6 adds the canonical structured seed without invalidating stored Phase
+# 1-5 packet fixtures. Production composers include these fields whenever the
+# sidecar has a profile; older saves continue with the authored five-field lens.
+PROFILE_SCHEMA["properties"].update(
+    copy.deepcopy(STRUCTURED_PROFILE_SCHEMA["properties"])
+)
+
+RELATIONSHIP_STATE_SCHEMA = strict_object(
+    {
+        "trust": {"type": "number", "minimum": -1, "maximum": 1},
+        "power": {"type": "number", "minimum": -1, "maximum": 1},
+        "intimacy": {"type": "number", "minimum": 0, "maximum": 1},
+        "fear": {"type": "number", "minimum": 0, "maximum": 1},
+        "respect": {"type": "number", "minimum": -1, "maximum": 1},
+    },
+    ("trust", "power", "intimacy", "fear", "respect"),
+)
+
+RECENT_EVENT_SCHEMA = strict_object(
+    {
+        "actor": {"type": "string", "minLength": 1, "maxLength": 100},
+        "target": {"type": "string", "minLength": 1, "maxLength": 100},
+        "eventType": {"type": "string", "enum": list(AFFINITY_EVENT_TYPES)},
+        "magnitude": {"type": "integer", "enum": [-3, -2, -1, 1, 2, 3]},
+        "witnessed": {"type": "boolean"},
+        "summary": {"type": "string", "minLength": 1, "maxLength": 240},
+    },
+    ("actor", "target", "eventType", "magnitude", "witnessed", "summary"),
+)
+
+RELATIONSHIP_EVIDENCE_SCHEMA = strict_object(
+    {
+        "actorId": {"type": "string", "minLength": 1, "maxLength": 240},
+        "actor": {"type": "string", "minLength": 1, "maxLength": 100},
+        "targetId": {"type": "string", "minLength": 1, "maxLength": 240},
+        "target": {"type": "string", "minLength": 1, "maxLength": 100},
+        "summary": {"type": "string", "minLength": 1, "maxLength": 240},
+        "witnessed": {"type": "boolean"},
+    },
+    ("actorId", "actor", "targetId", "target", "summary", "witnessed"),
+)
+
+COMMON_PACKET_PROPERTIES: Dict[str, Any] = {
+    "contractVersion": {"const": PACKET_VERSION},
+    "taskId": {"const": TASK_ID},
+    "mode": {"enum": ["COMBAT", "OUT_OF_COMBAT"]},
+    "beat": strict_object(
+        {
+            "id": {"type": "string", "minLength": 1, "maxLength": 120},
+            "summary": {"type": "string", "minLength": 1, "maxLength": 800},
+            "relationshipEvidence": {
+                "anyOf": [
+                    {"type": "null"},
+                    RELATIONSHIP_EVIDENCE_SCHEMA,
+                ]
+            },
+        },
+        ("id", "summary", "relationshipEvidence"),
+    ),
+    "npc": strict_object(
+        {
+            "id": {"type": "string", "minLength": 1, "maxLength": 240},
+            "name": {"type": "string", "minLength": 1, "maxLength": 100},
+            "role": {"type": "string", "minLength": 1, "maxLength": 160},
+            "profile": PROFILE_SCHEMA,
+        },
+        ("id", "name", "role", "profile"),
+    ),
+    "relationship": strict_object(
+        {
+            "counterpartyId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 240,
+            },
+            "counterpartyName": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100,
+            },
+            "state": RELATIONSHIP_STATE_SCHEMA,
+            "recentEvents": {
+                "type": "array",
+                "maxItems": 3,
+                "items": RECENT_EVENT_SCHEMA,
+            },
+        },
+        ("counterpartyId", "counterpartyName", "state", "recentEvents"),
+    ),
+    "scene": strict_object(
+        {
+            "module": {"type": "string", "minLength": 1, "maxLength": 160},
+            "locationId": {"type": "string", "minLength": 1, "maxLength": 120},
+            "location": {"type": "string", "minLength": 1, "maxLength": 240},
+            "presentActors": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 12,
+                "uniqueItems": True,
+                "items": {"type": "string", "minLength": 1, "maxLength": 100},
+            },
+            "stakes": {"type": "string", "minLength": 1, "maxLength": 500},
+            "recentEvents": {
+                "type": "array",
+                "maxItems": 6,
+                "items": {"type": "string", "minLength": 1, "maxLength": 400},
+            },
+        },
+        ("module", "locationId", "location", "presentActors", "stakes", "recentEvents"),
+    ),
+    "working": strict_object(
+        {
+            "currentGoal": {"type": "string", "maxLength": 300},
+            "priorPrivateIntent": {"type": "string", "maxLength": 300},
+            "openQuestion": {"type": "string", "maxLength": 240},
+            "moodTags": {
+                "type": "array",
+                "maxItems": 4,
+                "uniqueItems": True,
+                "items": {"type": "string", "minLength": 1, "maxLength": 60},
+            },
+            "expiresAfterTurn": {
+                "anyOf": [
+                    {"type": "null"},
+                    {"type": "integer", "minimum": 0},
+                ]
+            },
+        },
+        (
+            "currentGoal",
+            "priorPrivateIntent",
+            "openQuestion",
+            "moodTags",
+            "expiresAfterTurn",
+        ),
+    ),
+}
+
+COMBAT_CONTEXT_SCHEMA = strict_object(
+    {
+        "status": strict_object(
+            {
+                "hitPoints": strict_object(
+                    {
+                        "current": {"type": "integer", "minimum": 0},
+                        "maximum": {"type": "integer", "minimum": 1},
+                    },
+                    ("current", "maximum"),
+                ),
+                "armorClass": {"type": "integer", "minimum": 1, "maximum": 40},
+                "conditions": {
+                    "type": "array",
+                    "maxItems": 8,
+                    "uniqueItems": True,
+                    "items": {"type": "string", "minLength": 1, "maxLength": 80},
+                },
+                "position": {"type": "string", "minLength": 1, "maxLength": 240},
+            },
+            ("hitPoints", "armorClass", "conditions", "position"),
+        ),
+        "capabilities": {
+            "type": "array",
+            "maxItems": 8,
+            "items": {"type": "string", "minLength": 1, "maxLength": 240},
+        },
+        "allies": {
+            "type": "array",
+            "maxItems": 8,
+            "items": {"type": "string", "minLength": 1, "maxLength": 240},
+        },
+        "threats": {
+            "type": "array",
+            "maxItems": 8,
+            "items": strict_object(
+                {
+                    "name": {"type": "string", "minLength": 1, "maxLength": 100},
+                    "position": {"type": "string", "minLength": 1, "maxLength": 160},
+                    "intent": {"type": "string", "minLength": 1, "maxLength": 240},
+                },
+                ("name", "position", "intent"),
+            ),
+        },
+        "lastRoundEvents": {
+            "type": "array",
+            "maxItems": 8,
+            "items": {"type": "string", "minLength": 1, "maxLength": 320},
+        },
+    },
+    ("status", "capabilities", "allies", "threats", "lastRoundEvents"),
+)
+
+OUT_OF_COMBAT_CONTEXT_SCHEMA = strict_object(
+    {
+        "utilities": {
+            "type": "array",
+            "maxItems": 8,
+            "items": {"type": "string", "minLength": 1, "maxLength": 240},
+        },
+        "items": {
+            "type": "array",
+            "maxItems": 8,
+            "items": {"type": "string", "minLength": 1, "maxLength": 240},
+        },
+        "socialContext": {"type": "string", "minLength": 1, "maxLength": 800},
+        "currentGoals": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 5,
+            "items": {"type": "string", "minLength": 1, "maxLength": 300},
+        },
+    },
+    ("utilities", "items", "socialContext", "currentGoals"),
+)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def canonical_hash(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("ascii")).hexdigest()
+
+
+def packet_schema(mode: str) -> Dict[str, Any]:
+    properties = copy.deepcopy(COMMON_PACKET_PROPERTIES)
+    properties["context"] = (
+        COMBAT_CONTEXT_SCHEMA if mode == "COMBAT" else OUT_OF_COMBAT_CONTEXT_SCHEMA
+    )
+    return strict_object(properties, tuple(properties))
+
+
+def openai_response_format() -> Dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "npc_voice_response",
+            "strict": True,
+            "schema": copy.deepcopy(THOUGHT_RESPONSE_SCHEMA),
+        },
+    }
+
+
+def gemini_response_schema() -> Dict[str, Any]:
+    """Return Gemini's strict subset with a nullable event object."""
+    from model_config import convert_to_gemini_schema
+
+    non_nullable = copy.deepcopy(THOUGHT_RESPONSE_SCHEMA)
+    non_nullable["properties"]["affinityEvent"] = copy.deepcopy(
+        AFFINITY_EVENT_SCHEMA
+    )
+    converted = convert_to_gemini_schema(
+        non_nullable,
+        preserve_required=True,
+        preserve_constraints=True,
+    )
+    converted["properties"]["affinityEvent"]["nullable"] = True
+    return converted
+
+
+def profile_openai_response_format() -> Dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "npc_profile_seed_t107",
+            "strict": True,
+            "schema": copy.deepcopy(STRUCTURED_PROFILE_SCHEMA),
+        },
+    }
+
+
+def profile_gemini_response_schema() -> Dict[str, Any]:
+    from model_config import convert_to_gemini_schema
+
+    return convert_to_gemini_schema(
+        STRUCTURED_PROFILE_SCHEMA,
+        preserve_required=True,
+        preserve_constraints=True,
+    )
+
+
+def _first_error(schema: Mapping[str, Any], value: Any):
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(value),
+        key=lambda error: repr(list(error.path)),
+    )
+    return errors[0] if errors else None
+
+
+def validate_packet(packet: Mapping[str, Any]) -> Dict[str, Any]:
+    if not isinstance(packet, dict):
+        raise ThoughtContractError("packet must be an object")
+    mode = packet.get("mode")
+    if mode not in ("COMBAT", "OUT_OF_COMBAT"):
+        raise ThoughtContractError("packet mode must be COMBAT or OUT_OF_COMBAT")
+    error = _first_error(packet_schema(mode), packet)
+    if error is not None:
+        path = ".".join(str(part) for part in error.path) or "packet"
+        raise ThoughtContractError("invalid packet at %s: %s" % (path, error.message))
+
+    if mode == "COMBAT":
+        hp = packet["context"]["status"]["hitPoints"]
+        if hp["current"] > hp["maximum"]:
+            raise ThoughtContractError(
+                "current hit points cannot exceed maximum hit points"
+            )
+
+    npc = packet["npc"]
+    relationship = packet["relationship"]
+    if npc["id"] == relationship["counterpartyId"]:
+        raise ThoughtContractError("focal NPC and counterparty IDs must differ")
+    expected_names = {npc["name"], relationship["counterpartyName"]}
+    if not expected_names.issubset(set(packet["scene"]["presentActors"])):
+        raise ThoughtContractError(
+            "focal NPC and counterparty must both be present actors"
+        )
+
+    evidence = packet["beat"]["relationshipEvidence"]
+    if evidence is not None:
+        if (
+            evidence["actorId"] != relationship["counterpartyId"]
+            or evidence["actor"] != relationship["counterpartyName"]
+        ):
+            raise ThoughtContractError(
+                "relationship evidence actor must be the exact counterparty"
+            )
+        if evidence["targetId"] != npc["id"] or evidence["target"] != npc["name"]:
+            raise ThoughtContractError(
+                "relationship evidence target must be the exact focal NPC"
+            )
+    return copy.deepcopy(packet)
+
+
+def _strip_json_fence(text: str) -> str:
+    return re.sub(
+        r"^```(?:json)?\s*|\s*```$",
+        "",
+        text.strip(),
+        flags=re.IGNORECASE,
+    )
+
+
+def validate_thought_response(raw: Any, packet: Mapping[str, Any]) -> Dict[str, Any]:
+    packet_copy = validate_packet(packet)
+    try:
+        candidate = json.loads(_strip_json_fence(raw)) if isinstance(raw, str) else raw
+    except json.JSONDecodeError as exc:
+        raise ThoughtContractError(
+            "thought response is not JSON: %s" % exc.msg
+        ) from exc
+
+    error = _first_error(THOUGHT_RESPONSE_SCHEMA, candidate)
+    if error is not None:
+        path = ".".join(str(part) for part in error.path) or "response"
+        raise ThoughtContractError(
+            "invalid thought response at %s: %s" % (path, error.message)
+        )
+
+    thought = candidate["thought"].strip()
+    if not thought:
+        raise ThoughtContractError("thought must contain useful text")
+    if len(thought.split()) > MAX_THOUGHT_WORDS:
+        raise ThoughtContractError(
+            "thought exceeds %d words" % MAX_THOUGHT_WORDS
+        )
+    candidate["thought"] = thought
+
+    event = candidate["affinityEvent"]
+    evidence = packet_copy["beat"]["relationshipEvidence"]
+    if event is None:
+        return copy.deepcopy(candidate)
+    if evidence is None:
+        raise ThoughtContractError(
+            "affinity event requires supplied committed relationship evidence"
+        )
+
+    npc = packet_copy["npc"]
+    relationship = packet_copy["relationship"]
+    if (
+        event["actor"] != relationship["counterpartyName"]
+        or event["target"] != npc["name"]
+    ):
+        raise ThoughtContractError(
+            "affinity event must run from counterparty to focal NPC"
+        )
+    if event["actor"] != evidence["actor"] or event["target"] != evidence["target"]:
+        raise ThoughtContractError("affinity event participants must match evidence")
+    if event["witnessed"] is not evidence["witnessed"]:
+        raise ThoughtContractError("affinity event witnessed value must match evidence")
+    if (
+        event["eventType"] in POSITIVE_AFFINITY_EVENT_TYPES
+        and event["magnitude"] < 0
+    ):
+        raise ThoughtContractError("positive affinity event requires positive magnitude")
+    if (
+        event["eventType"] in NEGATIVE_AFFINITY_EVENT_TYPES
+        and event["magnitude"] > 0
+    ):
+        raise ThoughtContractError("negative affinity event requires negative magnitude")
+    return copy.deepcopy(candidate)

--- a/core/npc/voice_contracts.py
+++ b/core/npc/voice_contracts.py
@@ -13,9 +13,14 @@ from jsonschema import Draft202012Validator
 
 TASK_ID = "T105"
 PACKET_VERSION = "npc-voice-packet/v1"
-PROMPT_VERSION = "npc-voice-prompt/v2"
-RESPONSE_SCHEMA_VERSION = "npc-voice-response/v1"
+PROMPT_VERSION = "npc-voice-prompt/v3"
+RESPONSE_SCHEMA_VERSION = "npc-voice-response/v2"
 MAX_THOUGHT_WORDS = 80
+# Character caps for the enriched advisory fields (say/do/want). These are DM-facing
+# PROPOSALS the Dungeon Master edits/inlines/overrides; they are not final output.
+MAX_SAY_CHARS = 240
+MAX_DO_CHARS = 200
+MAX_WANT_CHARS = 200
 
 AFFINITY_EVENT_TYPES = (
     "abandon",
@@ -67,8 +72,27 @@ AFFINITY_EVENT_SCHEMA = strict_object(
     ("actor", "target", "eventType", "magnitude", "witnessed"),
 )
 
+def _nullable_string(max_len: int) -> Dict[str, Any]:
+    """A required key whose value is either null or a bounded non-empty string."""
+    return {
+        "anyOf": [
+            {"type": "null"},
+            {"type": "string", "minLength": 1, "maxLength": max_len},
+        ]
+    }
+
+
+# The enriched advisory voice response. In addition to the private ``thought`` and
+# the typed ``affinityEvent`` (unchanged), the NPC proposes what it would SAY (a
+# line of dialogue), what it would DO (an action/intent, no mechanics asserted),
+# and what it currently WANTs (a desire/goal). All three are ADVISORY: the Dungeon
+# Master reads them as input and may reword, cut, or override them for legality and
+# scene. say/do/want are nullable so an NPC with nothing to add returns null.
 THOUGHT_RESPONSE_SCHEMA = strict_object(
     {
+        "say": _nullable_string(MAX_SAY_CHARS),
+        "do": _nullable_string(MAX_DO_CHARS),
+        "want": _nullable_string(MAX_WANT_CHARS),
         "thought": {"type": "string", "minLength": 1, "maxLength": 640},
         "affinityEvent": {
             "anyOf": [
@@ -77,8 +101,15 @@ THOUGHT_RESPONSE_SCHEMA = strict_object(
             ]
         },
     },
+    # say/do/want are OPTIONAL, not required: the same schema/validator serves both
+    # the enriched voice call (which returns all three) and the isolated affinity
+    # classifier call (which returns only thought + affinityEvent). Absent fields
+    # are treated as null. thought + affinityEvent stay required.
     ("thought", "affinityEvent"),
 )
+# Clearer alias for the enriched contract (kept alongside the historical name so
+# existing imports keep working).
+VOICE_RESPONSE_SCHEMA = THOUGHT_RESPONSE_SCHEMA
 
 PROFILE_SCHEMA = strict_object(
     {
@@ -404,12 +435,27 @@ def gemini_response_schema() -> Dict[str, Any]:
     non_nullable["properties"]["affinityEvent"] = copy.deepcopy(
         AFFINITY_EVENT_SCHEMA
     )
+    # say/do/want are anyOf[null,string]; Gemini takes a single typed schema, so
+    # flatten each to a plain bounded string and mark it nullable after conversion.
+    _nullable_field_caps = {
+        "say": MAX_SAY_CHARS,
+        "do": MAX_DO_CHARS,
+        "want": MAX_WANT_CHARS,
+    }
+    for field_name, cap in _nullable_field_caps.items():
+        non_nullable["properties"][field_name] = {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": cap,
+        }
     converted = convert_to_gemini_schema(
         non_nullable,
         preserve_required=True,
         preserve_constraints=True,
     )
     converted["properties"]["affinityEvent"]["nullable"] = True
+    for field_name in _nullable_field_caps:
+        converted["properties"][field_name]["nullable"] = True
     return converted
 
 
@@ -519,6 +565,24 @@ def validate_thought_response(raw: Any, packet: Mapping[str, Any]) -> Dict[str, 
             "thought exceeds %d words" % MAX_THOUGHT_WORDS
         )
     candidate["thought"] = thought
+
+    # Normalize the enriched advisory fields: strip whitespace, collapse empty to
+    # null, enforce the character caps. These are STRUCTURAL checks only -- we never
+    # parse the prose for meaning (no verb/keyword gating); legality/mechanics are
+    # the Dungeon Master's job downstream.
+    _field_caps = {"say": MAX_SAY_CHARS, "do": MAX_DO_CHARS, "want": MAX_WANT_CHARS}
+    for field_name, cap in _field_caps.items():
+        value = candidate.get(field_name)
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if not trimmed:
+                candidate[field_name] = None
+            elif len(trimmed) > cap:
+                raise ThoughtContractError(
+                    "%s exceeds %d characters" % (field_name, cap)
+                )
+            else:
+                candidate[field_name] = trimmed
 
     event = candidate["affinityEvent"]
     evidence = packet_copy["beat"]["relationshipEvidence"]

--- a/core/npc/voice_packets.py
+++ b/core/npc/voice_packets.py
@@ -1,0 +1,266 @@
+"""Packet composers for the two T105 context lenses."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Mapping, Optional
+
+from core.npc.voice_contracts import (
+    PACKET_VERSION,
+    TASK_ID,
+    ThoughtContractError,
+    canonical_json,
+    validate_packet,
+)
+
+
+MAX_PACKET_CHARS = 4800
+
+
+def _text(value: Any, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()[:limit]
+
+
+def _text_list(values: Any, count: int, limit: int) -> List[str]:
+    if not isinstance(values, list):
+        return []
+    result = []
+    for value in values:
+        item = _text(value, limit)
+        if item and item not in result:
+            result.append(item)
+        if len(result) >= count:
+            break
+    return result
+
+
+def _normalize_common(packet: Dict[str, Any]) -> None:
+    packet["beat"]["id"] = _text(packet["beat"].get("id"), 120)
+    packet["beat"]["summary"] = _text(packet["beat"].get("summary"), 800)
+    evidence = packet["beat"].get("relationshipEvidence")
+    if isinstance(evidence, dict):
+        for key, limit in (
+            ("actorId", 240),
+            ("actor", 100),
+            ("targetId", 240),
+            ("target", 100),
+            ("summary", 240),
+        ):
+            evidence[key] = _text(evidence.get(key), limit)
+
+    npc = packet["npc"]
+    npc["id"] = _text(npc.get("id"), 240)
+    npc["name"] = _text(npc.get("name"), 100)
+    npc["role"] = _text(npc.get("role"), 160)
+    profile = npc["profile"]
+    for key, limit in (
+        ("background", 800),
+        ("personality", 800),
+        ("ideals", 400),
+        ("bonds", 400),
+        ("flaws", 400),
+    ):
+        profile[key] = _text(profile.get(key), limit)
+    structured_voice = profile.get("voice")
+    if isinstance(structured_voice, dict):
+        structured_voice["cadence"] = _text(structured_voice.get("cadence"), 120)
+        structured_voice["diction"] = _text(structured_voice.get("diction"), 120)
+        structured_voice["taboos"] = _text_list(
+            structured_voice.get("taboos"), 3, 80
+        )
+    for key, count, limit in (
+        ("goals", 3, 180),
+        ("fears", 3, 180),
+        ("values", 5, 120),
+        ("preferences", 5, 120),
+        ("boundaries", 5, 160),
+        ("protectionPriorities", 3, 120),
+        ("retreatRules", 3, 160),
+        ("arcSeeds", 2, 180),
+    ):
+        if key in profile:
+            profile[key] = _text_list(profile.get(key), count, limit)
+    if "conflictStyle" in profile:
+        profile["conflictStyle"] = _text(profile.get("conflictStyle"), 160)
+
+    relationship = packet["relationship"]
+    relationship["counterpartyId"] = _text(
+        relationship.get("counterpartyId"), 240
+    )
+    relationship["counterpartyName"] = _text(
+        relationship.get("counterpartyName"), 100
+    )
+    recent_events = relationship.get("recentEvents", [])[:3]
+    for event in recent_events:
+        if isinstance(event, dict):
+            event["actor"] = _text(event.get("actor"), 100)
+            event["target"] = _text(event.get("target"), 100)
+            event["summary"] = _text(event.get("summary"), 240)
+    relationship["recentEvents"] = recent_events
+
+    scene = packet["scene"]
+    scene["module"] = _text(scene.get("module"), 160)
+    scene["locationId"] = _text(scene.get("locationId"), 120)
+    scene["location"] = _text(scene.get("location"), 240)
+    scene["presentActors"] = _text_list(scene.get("presentActors"), 12, 100)
+    scene["stakes"] = _text(scene.get("stakes"), 500)
+    scene["recentEvents"] = _text_list(scene.get("recentEvents"), 6, 400)
+
+    working = packet["working"]
+    working["currentGoal"] = _text(working.get("currentGoal"), 300)
+    working["priorPrivateIntent"] = _text(
+        working.get("priorPrivateIntent"), 300
+    )
+    working["openQuestion"] = _text(working.get("openQuestion"), 240)
+    working["moodTags"] = _text_list(working.get("moodTags"), 4, 60)
+
+
+def _shrink_longest(packet: Dict[str, Any]) -> bool:
+    candidates = [
+        (packet["npc"]["profile"], "background", 80),
+        (packet["npc"]["profile"], "personality", 80),
+        (packet["context"], "socialContext", 80),
+        (packet["npc"]["profile"], "ideals", 40),
+        (packet["npc"]["profile"], "bonds", 40),
+        (packet["npc"]["profile"], "flaws", 40),
+    ]
+    available = [entry for entry in candidates if len(entry[0].get(entry[1], "")) > entry[2]]
+    if not available:
+        return False
+    container, key, minimum = max(
+        available,
+        key=lambda entry: (len(entry[0][entry[1]]), entry[1]),
+    )
+    value = container[key]
+    new_length = max(minimum, len(value) - max(32, len(value) // 4))
+    container[key] = value[:new_length].rstrip()
+    return True
+
+
+def _fit_packet(packet: Dict[str, Any], max_chars: int) -> Dict[str, Any]:
+    if max_chars <= 0:
+        raise ThoughtContractError("packet character budget must be positive")
+    while len(canonical_json(packet)) > max_chars:
+        if packet["scene"]["recentEvents"]:
+            packet["scene"]["recentEvents"].pop(0)
+        elif packet["relationship"]["recentEvents"]:
+            packet["relationship"]["recentEvents"].pop()
+        elif packet["mode"] == "OUT_OF_COMBAT" and packet["context"]["items"]:
+            packet["context"]["items"].pop()
+        elif packet["mode"] == "OUT_OF_COMBAT" and packet["context"]["utilities"]:
+            packet["context"]["utilities"].pop()
+        elif packet["mode"] == "COMBAT" and packet["context"]["lastRoundEvents"]:
+            packet["context"]["lastRoundEvents"].pop(0)
+        elif not _shrink_longest(packet):
+            raise ThoughtContractError("packet exceeds the T105 input budget")
+    return validate_packet(packet)
+
+
+def _base_packet(
+    mode: str,
+    beat: Mapping[str, Any],
+    npc: Mapping[str, Any],
+    relationship: Mapping[str, Any],
+    scene: Mapping[str, Any],
+    working: Mapping[str, Any],
+) -> Dict[str, Any]:
+    packet = {
+        "contractVersion": PACKET_VERSION,
+        "taskId": TASK_ID,
+        "mode": mode,
+        "beat": copy.deepcopy(dict(beat)),
+        "npc": copy.deepcopy(dict(npc)),
+        "relationship": copy.deepcopy(dict(relationship)),
+        "scene": copy.deepcopy(dict(scene)),
+        "working": copy.deepcopy(dict(working)),
+    }
+    return packet
+
+
+def compose_out_of_combat_packet(
+    *,
+    beat: Mapping[str, Any],
+    npc: Mapping[str, Any],
+    relationship: Mapping[str, Any],
+    scene: Mapping[str, Any],
+    working: Mapping[str, Any],
+    utilities: List[str],
+    items: List[str],
+    social_context: str,
+    current_goals: List[str],
+    max_chars: Optional[int] = None,
+) -> Dict[str, Any]:
+    packet = _base_packet(
+        "OUT_OF_COMBAT", beat, npc, relationship, scene, working
+    )
+    packet["context"] = {
+        "utilities": copy.deepcopy(utilities),
+        "items": copy.deepcopy(items),
+        "socialContext": social_context,
+        "currentGoals": copy.deepcopy(current_goals),
+    }
+    _normalize_common(packet)
+    packet["context"]["utilities"] = _text_list(
+        packet["context"].get("utilities"), 8, 240
+    )
+    packet["context"]["items"] = _text_list(
+        packet["context"].get("items"), 8, 240
+    )
+    packet["context"]["socialContext"] = _text(
+        packet["context"].get("socialContext"), 800
+    )
+    packet["context"]["currentGoals"] = _text_list(
+        packet["context"].get("currentGoals"), 5, 300
+    )
+    budget = MAX_PACKET_CHARS if max_chars is None else max_chars
+    return _fit_packet(packet, budget)
+
+
+def compose_combat_packet(
+    *,
+    beat: Mapping[str, Any],
+    npc: Mapping[str, Any],
+    relationship: Mapping[str, Any],
+    scene: Mapping[str, Any],
+    working: Mapping[str, Any],
+    status: Mapping[str, Any],
+    capabilities: List[str],
+    allies: List[str],
+    threats: List[Mapping[str, Any]],
+    last_round_events: List[str],
+    max_chars: Optional[int] = None,
+) -> Dict[str, Any]:
+    packet = _base_packet("COMBAT", beat, npc, relationship, scene, working)
+    packet["context"] = {
+        "status": copy.deepcopy(dict(status)),
+        "capabilities": copy.deepcopy(capabilities),
+        "allies": copy.deepcopy(allies),
+        "threats": copy.deepcopy(threats),
+        "lastRoundEvents": copy.deepcopy(last_round_events),
+    }
+    _normalize_common(packet)
+    packet["context"]["capabilities"] = _text_list(
+        packet["context"].get("capabilities"), 8, 240
+    )
+    packet["context"]["allies"] = _text_list(
+        packet["context"].get("allies"), 8, 240
+    )
+    packet["context"]["lastRoundEvents"] = _text_list(
+        packet["context"].get("lastRoundEvents"), 8, 320
+    )
+    threats_result = []
+    for threat in packet["context"].get("threats", [])[:8]:
+        if not isinstance(threat, dict):
+            continue
+        threats_result.append(
+            {
+                "name": _text(threat.get("name"), 100),
+                "position": _text(threat.get("position"), 160),
+                "intent": _text(threat.get("intent"), 240),
+            }
+        )
+    packet["context"]["threats"] = threats_result
+    budget = MAX_PACKET_CHARS if max_chars is None else max_chars
+    return _fit_packet(packet, budget)

--- a/core/npc/voice_selection.py
+++ b/core/npc/voice_selection.py
@@ -1,0 +1,138 @@
+"""Deterministic out-of-combat NPC relevance and fairness selection."""
+
+from __future__ import annotations
+
+import re
+import threading
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+
+class SelectionFairness:
+    """Process-long least-recently-merged rotation keyed by stable NPC ID."""
+
+    def __init__(self) -> None:
+        self._last_merged: Dict[str, int] = {}
+        self._turn = 0
+        self._lock = threading.Lock()
+
+    def last_merged(self, npc_id: str) -> int:
+        with self._lock:
+            return self._last_merged.get(npc_id, -1)
+
+    def record_merged(self, npc_ids: Iterable[str]) -> None:
+        stable_ids = {str(value) for value in npc_ids if str(value)}
+        if not stable_ids:
+            return
+        with self._lock:
+            self._turn += 1
+            for npc_id in stable_ids:
+                self._last_merged[npc_id] = self._turn
+
+
+def _exact_name_mentioned(name: str, raw_input: str) -> bool:
+    if not name or not raw_input:
+        return False
+    pattern = r"(?<!\w)%s(?!\w)" % re.escape(name)
+    return re.search(pattern, raw_input, flags=re.IGNORECASE) is not None
+
+
+def _name_tokens(value: str) -> set[str]:
+    return {
+        token.casefold()
+        for token in re.findall(r"[^\W_]+", value, flags=re.UNICODE)
+        if token
+    }
+
+
+def resolve_ooc_mention(
+    party_npcs: Iterable[Mapping[str, Any]], raw_input: str
+) -> Tuple[Optional[Dict[str, Any]], bool]:
+    """Resolve one exact or unique name-token mention.
+
+    The boolean is true when name-like input matched multiple roster NPCs and
+    therefore must not be used to choose a relationship edge.
+    """
+    candidates = [dict(npc) for npc in party_npcs if isinstance(npc, dict)]
+    exact_indexes = [
+        index
+        for index, npc in enumerate(candidates)
+        if _exact_name_mentioned(str(npc.get("name", "")), raw_input)
+    ]
+    if len(exact_indexes) == 1:
+        return candidates[exact_indexes[0]], False
+    if len(exact_indexes) > 1:
+        return None, True
+
+    roster_tokens: Dict[str, set[int]] = {}
+    for index, npc in enumerate(candidates):
+        for token in _name_tokens(str(npc.get("name", ""))):
+            roster_tokens.setdefault(token, set()).add(index)
+
+    unique_indexes = set()
+    shared_token_matched = False
+    for token in _name_tokens(raw_input):
+        indexes = roster_tokens.get(token, set())
+        if len(indexes) == 1:
+            unique_indexes.update(indexes)
+        elif len(indexes) > 1:
+            shared_token_matched = True
+    if len(unique_indexes) == 1:
+        return candidates[next(iter(unique_indexes))], False
+    if len(unique_indexes) > 1 or shared_token_matched:
+        return None, True
+    return None, False
+
+
+def rank_ooc_candidates(
+    party_npcs: Iterable[Mapping[str, Any]],
+    raw_input: str,
+    *,
+    evidence_npc_ids: Optional[Iterable[str]] = None,
+    fairness: Optional[SelectionFairness] = None,
+    limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Rank mention, evidence, and least-recent merge with stable ID ties.
+
+    The legacy Phase 1 call shape retains roster order after its mention when
+    no Phase 3 relevance inputs are supplied.
+    """
+    candidates = [dict(npc) for npc in party_npcs if isinstance(npc, dict)]
+    mentioned, _ambiguous = resolve_ooc_mention(candidates, raw_input)
+    if evidence_npc_ids is None and fairness is None and limit is None:
+        if mentioned is None:
+            return candidates
+        return [mentioned] + [npc for npc in candidates if npc != mentioned]
+
+    mentioned_name = str(mentioned.get("name", "")) if mentioned else ""
+    evidence_ids = {str(value) for value in (evidence_npc_ids or ())}
+
+    def stable_id(candidate: Mapping[str, Any]) -> str:
+        return str(
+            candidate.get("npcId")
+            or candidate.get("id")
+            or candidate.get("name")
+            or ""
+        )
+
+    def rank(candidate: Mapping[str, Any]) -> tuple[int, int, int, str]:
+        npc_id = stable_id(candidate)
+        return (
+            0
+            if mentioned_name and str(candidate.get("name", "")) == mentioned_name
+            else 1,
+            0 if npc_id in evidence_ids else 1,
+            fairness.last_merged(npc_id) if fairness is not None else -1,
+            npc_id,
+        )
+
+    ranked = sorted(candidates, key=rank)
+    if limit is None:
+        return ranked
+    return ranked[: max(0, int(limit))]
+
+
+def select_ooc_candidate(
+    party_npcs: Iterable[Mapping[str, Any]], raw_input: str
+) -> Optional[Dict[str, Any]]:
+    ranked = rank_ooc_candidates(party_npcs, raw_input)
+    return ranked[0] if ranked else None

--- a/core/npc/voice_service.py
+++ b/core/npc/voice_service.py
@@ -1,0 +1,951 @@
+"""Best-effort T105 NPC voice service."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from collections import OrderedDict, deque
+from concurrent.futures import ThreadPoolExecutor, wait
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Deque, Dict, Iterable, Mapping, Optional, Tuple
+
+import model_config
+from core.ai import api_client
+from core.npc.voice_contracts import (
+    PROMPT_VERSION,
+    RESPONSE_SCHEMA_VERSION,
+    TASK_ID,
+    ThoughtContractError,
+    canonical_hash,
+    validate_packet,
+    validate_thought_response,
+)
+from utils.capture import multi_model_capture as capture_module
+from utils.capture.multi_model_capture import capture_and_fanout, register_callsite
+
+
+register_callsite("T105", "core/npc/voice_service.py", 552)
+
+TEMPERATURE = 0.6
+MAX_OUTPUT_TOKENS = 180
+MAX_ATTEMPTS = 2
+DEFAULT_DEADLINE_SECONDS = 4.0
+MAX_LOGICAL_NPCS = 4
+MAX_PHYSICAL_REQUESTS = 8
+
+_LOGGER = logging.getLogger(__name__)
+_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="npc-voice")
+_WORKER_SLOTS = threading.BoundedSemaphore(4)
+
+
+@dataclass(frozen=True)
+class Usage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+@dataclass(frozen=True)
+class VoiceTelemetryRecord:
+    """One sanitized developer-only NPC voice diagnostic."""
+
+    kind: str
+    disposition: str
+    batch_hash: str = ""
+    npc_hash: str = ""
+    request_kind: str = ""
+    attempt: int = 0
+    latency_ms: int = 0
+    usage: Usage = Usage()
+    cost_usd: Optional[float] = None
+    provider: str = ""
+    model: str = ""
+    candidate_count: int = 0
+    physical_request_count: int = 0
+    merged_count: int = 0
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        value: Dict[str, Any] = {
+            "kind": self.kind,
+            "disposition": self.disposition,
+            "batchHash": self.batch_hash,
+            "npcHash": self.npc_hash,
+            "requestKind": self.request_kind,
+            "attempt": self.attempt,
+            "latencyMs": self.latency_ms,
+            "tokens": {
+                "prompt": self.usage.prompt_tokens,
+                "completion": self.usage.completion_tokens,
+                "total": self.usage.total_tokens,
+            },
+            "provider": self.provider,
+            "model": self.model,
+            "candidateCount": self.candidate_count,
+            "physicalRequestCount": self.physical_request_count,
+            "mergedCount": self.merged_count,
+            "timestamp": self.timestamp,
+        }
+        if self.cost_usd is not None:
+            value["costUsd"] = self.cost_usd
+            value["costDisposition"] = "known"
+        else:
+            value["costDisposition"] = "unknown"
+        return {key: item for key, item in value.items() if item not in ("", None)}
+
+
+class VoiceTelemetry:
+    """Bounded, thread-safe telemetry with no packet, thought, name, or error text."""
+
+    def __init__(
+        self,
+        max_records: int = 4096,
+        path: Optional[os.PathLike[str] | str] = None,
+    ) -> None:
+        self._records: Deque[VoiceTelemetryRecord] = deque(maxlen=max_records)
+        self._lock = threading.Lock()
+        configured_path = path or os.environ.get("NPC_VOICE_TELEMETRY_PATH")
+        self._path = Path(configured_path) if configured_path else None
+        self._write_lock = threading.Lock()
+
+    def record(self, record: VoiceTelemetryRecord) -> None:
+        with self._lock:
+            self._records.append(record)
+        if self._path is None:
+            return
+        with self._write_lock:
+            try:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                with self._path.open("a", encoding="ascii") as handle:
+                    handle.write(
+                        json.dumps(
+                            record.to_dict(),
+                            ensure_ascii=True,
+                            separators=(",", ":"),
+                        )
+                        + "\n"
+                    )
+            except Exception:
+                pass
+
+    def snapshot(self) -> Tuple[VoiceTelemetryRecord, ...]:
+        with self._lock:
+            return tuple(self._records)
+
+    def record_disposition(
+        self,
+        kind: str,
+        disposition: str,
+        *,
+        batch_id: str = "",
+        npc_id: str = "",
+    ) -> None:
+        try:
+            self.record(
+                VoiceTelemetryRecord(
+                    kind=_safe_identifier(kind),
+                    disposition=_safe_identifier(disposition),
+                    batch_hash=_identifier_hash(batch_id) if batch_id else "",
+                    npc_hash=_identifier_hash(npc_id) if npc_id else "",
+                )
+            )
+        except Exception:
+            pass
+
+
+def _safe_identifier(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return "".join(
+        character
+        for character in value
+        if character.isalnum() or character in "._-"
+    )[:120]
+
+
+def _identifier_hash(value: Any) -> str:
+    return hashlib.sha256(str(value).encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _configured_cost(model: str, usage: Usage, provider: str) -> Optional[float]:
+    if provider == "lmstudio":
+        return 0.0
+    try:
+        return capture_module._calculate_cost(
+            model,
+            {
+                "prompt_tokens": usage.prompt_tokens,
+                "completion_tokens": usage.completion_tokens,
+                "total_tokens": usage.total_tokens,
+            },
+            capture_module._load_config(),
+        )
+    except Exception:
+        return None
+
+
+class _RequestBudget:
+    def __init__(self, deadline_seconds: float) -> None:
+        self.deadline = time.perf_counter() + max(0.0, deadline_seconds)
+        self._count = 0
+        self._lock = threading.Lock()
+
+    def claim(self) -> bool:
+        with self._lock:
+            if self._count >= MAX_PHYSICAL_REQUESTS:
+                return False
+            if time.perf_counter() >= self.deadline:
+                return False
+            self._count += 1
+            return True
+
+    @property
+    def count(self) -> int:
+        with self._lock:
+            return self._count
+
+    def remaining(self) -> float:
+        return max(0.0, self.deadline - time.perf_counter())
+
+
+class _GenerationRegistry:
+    def __init__(self) -> None:
+        self._next = 0
+        self._active = set()
+        self._lock = threading.Lock()
+
+    def issue(self) -> str:
+        with self._lock:
+            self._next += 1
+            token = "voice-generation-%d" % self._next
+            self._active.add(token)
+            return token
+
+    def expire(self, token: str) -> None:
+        with self._lock:
+            self._active.discard(token)
+
+    def active(self, token: str) -> bool:
+        with self._lock:
+            return token in self._active
+
+
+_GENERATIONS = _GenerationRegistry()
+
+
+@dataclass(frozen=True)
+class NpcVoiceResult:
+    npc_id: str
+    npc_name: str
+    content_hash: str
+    thought: str
+    affinity_event: Optional[Dict[str, Any]]
+    model: str
+    usage: Usage
+    latency_seconds: float
+    cached: bool = False
+    source_turn_id: str = ""
+    counterparty_id: str = ""
+    relationship_evidence_summary: str = ""
+    relationship_evidence_id: str = ""
+    packet_hash: str = ""
+    module: str = ""
+    location_id: str = ""
+    current_goal_reference: str = ""
+    open_question: str = ""
+    mood_tags: Tuple[str, ...] = ()
+    expires_after_turn: Optional[int] = None
+    scene_id: str = ""
+    generation_token: str = ""
+    completed_at: float = field(default=0.0, repr=False, compare=False)
+    cacheable: bool = field(default=True, repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class NpcVoiceBatch:
+    batch_id: str
+    results: Tuple[NpcVoiceResult, ...]
+    generation_token: str = ""
+    candidate_count: int = 0
+    physical_request_count: int = 0
+    telemetry: Optional[VoiceTelemetry] = field(default=None, repr=False, compare=False)
+
+
+class NpcVoiceUnavailable(RuntimeError):
+    """All bounded T105 attempts failed."""
+
+
+class VoiceCache:
+    """Thread-safe validated-result LRU."""
+
+    def __init__(self, max_entries: int = 256) -> None:
+        self.max_entries = max_entries
+        self._values: OrderedDict[str, NpcVoiceResult] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: str) -> Optional[NpcVoiceResult]:
+        with self._lock:
+            value = self._values.get(key)
+            if value is None:
+                return None
+            self._values.move_to_end(key)
+            return value
+
+    def put(self, key: str, value: NpcVoiceResult) -> None:
+        with self._lock:
+            self._values[key] = value
+            self._values.move_to_end(key)
+            while len(self._values) > self.max_entries:
+                self._values.popitem(last=False)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._values)
+
+
+def _usage_from_response(response: Any) -> Usage:
+    usage = getattr(response, "usage", None)
+    return Usage(
+        prompt_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+        completion_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+        total_tokens=int(getattr(usage, "total_tokens", 0) or 0),
+    )
+
+
+def _prompt_text() -> str:
+    prompt_path = (
+        Path(__file__).resolve().parents[2]
+        / "prompts"
+        / "npc"
+        / "npc_voice_t105.txt"
+    )
+    return prompt_path.read_text(encoding="ascii").strip()
+
+
+def _classification_prompt_text() -> str:
+    prompt_path = (
+        Path(__file__).resolve().parents[2]
+        / "prompts"
+        / "npc"
+        / "npc_affinity_t105.txt"
+    )
+    return prompt_path.read_text(encoding="ascii").strip()
+
+
+def build_messages(
+    packet: Mapping[str, Any], retry_reason: Optional[str] = None
+) -> list[Dict[str, str]]:
+    messages = [{"role": "system", "content": _prompt_text()}]
+    if retry_reason:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "The previous private response failed the strict contract "
+                    "(%s). Return a corrected exact JSON object only." % retry_reason
+                ),
+            }
+        )
+    messages.append(
+        {
+            "role": "user",
+            "content": json.dumps(
+                packet,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        }
+    )
+    return messages
+
+
+def build_classification_messages(
+    relationship_evidence: Mapping[str, Any],
+    retry_reason: Optional[str] = None,
+) -> list[Dict[str, str]]:
+    """Build an isolated classifier request containing only one accepted pair."""
+    messages = [{"role": "system", "content": _classification_prompt_text()}]
+    if retry_reason:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "The previous private response failed the strict contract "
+                    "(%s). Return a corrected exact JSON object only." % retry_reason
+                ),
+            }
+        )
+    messages.append(
+        {
+            "role": "user",
+            "content": json.dumps(
+                {"relationshipEvidence": dict(relationship_evidence)},
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        }
+    )
+    return messages
+
+
+def _config_for_provider(provider: str) -> Dict[str, Any]:
+    if provider == "openai":
+        selected = model_config.NPC_VOICE_T105_OPENAI_LUNA_NONE
+    elif provider == "gemini":
+        selected = model_config.NPC_VOICE_T105_GEMINI_FLASHLITE_LOW
+    elif provider == "lmstudio":
+        selected = model_config.NPC_VOICE_T105_LMSTUDIO
+    elif provider == "legacy":
+        selected = model_config.NPC_VOICE_T105_LEGACY
+    else:
+        raise ValueError("unsupported T105 provider: %s" % provider)
+    return copy.deepcopy(selected)
+
+
+class NpcVoiceService:
+    """Bounded process-long fanout service shared by both packet lenses."""
+
+    def __init__(
+        self,
+        completion_fn: Callable[..., Any] = api_client.create_completion,
+        *,
+        capture_fn: Callable[..., Any] = capture_and_fanout,
+        cache: Optional[VoiceCache] = None,
+        telemetry: Optional[VoiceTelemetry] = None,
+        cost_fn: Callable[[str, Usage, str], Optional[float]] = _configured_cost,
+    ) -> None:
+        self.completion_fn = completion_fn
+        self.capture_fn = capture_fn
+        self.cache = cache if cache is not None else VoiceCache()
+        self.telemetry = telemetry if telemetry is not None else VoiceTelemetry()
+        self.cost_fn = cost_fn
+
+    def _record(
+        self,
+        *,
+        kind: str,
+        disposition: str,
+        batch_id: str = "",
+        npc_id: str = "",
+        request_kind: str = "",
+        attempt: int = 0,
+        latency_seconds: float = 0.0,
+        usage: Usage = Usage(),
+        cost_usd: Optional[float] = None,
+        provider: str = "",
+        model: str = "",
+        candidate_count: int = 0,
+        physical_request_count: int = 0,
+        merged_count: int = 0,
+    ) -> None:
+        try:
+            self.telemetry.record(
+                VoiceTelemetryRecord(
+                    kind=kind,
+                    disposition=disposition,
+                    batch_hash=_identifier_hash(batch_id) if batch_id else "",
+                    npc_hash=_identifier_hash(npc_id) if npc_id else "",
+                    request_kind=_safe_identifier(request_kind),
+                    attempt=max(0, int(attempt)),
+                    latency_ms=max(0, int(round(latency_seconds * 1000))),
+                    usage=usage,
+                    cost_usd=cost_usd,
+                    provider=_safe_identifier(provider),
+                    model=_safe_identifier(model),
+                    candidate_count=max(0, int(candidate_count)),
+                    physical_request_count=max(0, int(physical_request_count)),
+                    merged_count=max(0, int(merged_count)),
+                )
+            )
+        except Exception:
+            pass
+
+    def _cost(self, model: str, usage: Usage, provider: str) -> Optional[float]:
+        try:
+            return self.cost_fn(model, usage, provider)
+        except Exception:
+            return None
+
+    def _cache_key(self, packet: Mapping[str, Any], provider: str) -> str:
+        return canonical_hash(
+            {
+                "packet": packet,
+                "promptVersion": PROMPT_VERSION,
+                "responseSchemaVersion": RESPONSE_SCHEMA_VERSION,
+                "profileStoreRevision": canonical_hash(
+                    {
+                        "profile": packet.get("npc", {}).get("profile"),
+                        "relationship": packet.get("relationship"),
+                        "working": packet.get("working"),
+                    }
+                ),
+                "modelConfig": _config_for_provider(provider),
+                "provider": provider,
+            }
+        )
+
+    def think(self, packet: Mapping[str, Any]) -> NpcVoiceResult:
+        packet_copy = validate_packet(packet)
+        token = _GENERATIONS.issue()
+        budget = _RequestBudget(DEFAULT_DEADLINE_SECONDS)
+        try:
+            return self._think_with_provider(
+                packet_copy,
+                model_config.get_provider(),
+                budget=budget,
+                generation_token=token,
+                cache_result=True,
+            )
+        finally:
+            _GENERATIONS.expire(token)
+
+    def _request_validated(
+        self,
+        *,
+        request_packet: Mapping[str, Any],
+        validation_packet: Mapping[str, Any],
+        provider: str,
+        classification: bool,
+        budget: _RequestBudget,
+        generation_token: str,
+        batch_id: str,
+        npc_id: str,
+    ) -> tuple[Dict[str, Any], Any, str]:
+        last_error: Optional[BaseException] = None
+        retry_reason: Optional[str] = None
+        for attempt in range(MAX_ATTEMPTS):
+            config = _config_for_provider(provider)
+            model = config.pop("model")
+            request_kind = "classification" if classification else "thought"
+            if not budget.claim():
+                self._record(
+                    kind="request_omission",
+                    disposition="budget_or_deadline",
+                    batch_id=batch_id,
+                    npc_id=npc_id,
+                    request_kind=request_kind,
+                    attempt=attempt + 1,
+                    provider=provider,
+                    model=model,
+                )
+                break
+            if classification:
+                messages = build_classification_messages(
+                    request_packet["beat"]["relationshipEvidence"],
+                    retry_reason,
+                )
+            else:
+                messages = build_messages(request_packet, retry_reason)
+            started = time.perf_counter()
+            response = None
+            try:
+                response = self.capture_fn(
+                    TASK_ID,
+                    self.completion_fn,
+                    _request_provider=provider,
+                    messages=messages,
+                    model=model,
+                    temperature=TEMPERATURE,
+                    max_tokens=MAX_OUTPUT_TOKENS,
+                    retry_attempt=attempt,
+                    **config,
+                )
+                raw = response.choices[0].message.content
+                validated = validate_thought_response(raw, validation_packet)
+                usage = _usage_from_response(response)
+                effective_model = getattr(response, "model", None) or model
+                disposition = (
+                    "valid"
+                    if _GENERATIONS.active(generation_token)
+                    else "late_result_rejected"
+                )
+                self._record(
+                    kind="physical_call",
+                    disposition=disposition,
+                    batch_id=batch_id,
+                    npc_id=npc_id,
+                    request_kind=request_kind,
+                    attempt=attempt + 1,
+                    latency_seconds=time.perf_counter() - started,
+                    usage=usage,
+                    cost_usd=self._cost(effective_model, usage, provider),
+                    provider=provider,
+                    model=effective_model,
+                )
+                return validated, response, model
+            except ThoughtContractError as exc:
+                last_error = exc
+                retry_reason = "invalid_contract"
+                usage = _usage_from_response(response)
+                effective_model = getattr(response, "model", None) or model
+                self._record(
+                    kind="physical_call",
+                    disposition="invalid_contract",
+                    batch_id=batch_id,
+                    npc_id=npc_id,
+                    request_kind=request_kind,
+                    attempt=attempt + 1,
+                    latency_seconds=time.perf_counter() - started,
+                    usage=usage,
+                    cost_usd=self._cost(effective_model, usage, provider),
+                    provider=provider,
+                    model=effective_model,
+                )
+            except Exception as exc:
+                last_error = exc
+                retry_reason = "provider_failure"
+                self._record(
+                    kind="physical_call",
+                    disposition="provider_failure",
+                    batch_id=batch_id,
+                    npc_id=npc_id,
+                    request_kind=request_kind,
+                    attempt=attempt + 1,
+                    latency_seconds=time.perf_counter() - started,
+                    provider=provider,
+                    model=model,
+                )
+        raise NpcVoiceUnavailable("T105 attempts exhausted") from last_error
+
+    def _think_with_provider(
+        self,
+        packet: Mapping[str, Any],
+        provider: str,
+        *,
+        budget: _RequestBudget,
+        generation_token: str,
+        cache_result: bool,
+    ) -> NpcVoiceResult:
+        packet_copy = validate_packet(packet)
+        batch_id = packet_copy["beat"]["id"]
+        npc_id = packet_copy["npc"]["id"]
+        key = self._cache_key(packet_copy, provider)
+        cached = self.cache.get(key)
+        if cached is not None:
+            self._record(
+                kind="cache",
+                disposition="hit",
+                batch_id=batch_id,
+                npc_id=npc_id,
+                provider=provider,
+                model=cached.model,
+            )
+            return replace(
+                cached,
+                usage=Usage(),
+                latency_seconds=0.0,
+                cached=True,
+                generation_token=generation_token,
+                completed_at=time.perf_counter(),
+            )
+
+        started = time.perf_counter()
+        thought_packet = copy.deepcopy(packet_copy)
+        thought_packet["beat"]["relationshipEvidence"] = None
+        validated, thought_response, thought_model = self._request_validated(
+            request_packet=thought_packet,
+            validation_packet=thought_packet,
+            provider=provider,
+            classification=False,
+            budget=budget,
+            generation_token=generation_token,
+            batch_id=batch_id,
+            npc_id=npc_id,
+        )
+        affinity_event = None
+        classification_response = None
+        classification_complete = (
+            packet_copy["beat"]["relationshipEvidence"] is None
+        )
+        if packet_copy["beat"]["relationshipEvidence"] is not None:
+            try:
+                classified, classification_response, _classification_model = (
+                    self._request_validated(
+                        request_packet=packet_copy,
+                        validation_packet=packet_copy,
+                        provider=provider,
+                        classification=True,
+                        budget=budget,
+                        generation_token=generation_token,
+                        batch_id=batch_id,
+                        npc_id=npc_id,
+                    )
+                )
+                affinity_event = classified["affinityEvent"]
+                classification_complete = True
+            except NpcVoiceUnavailable:
+                _LOGGER.debug("T105 isolated classification skipped")
+
+        thought_usage = _usage_from_response(thought_response)
+        classification_usage = _usage_from_response(classification_response)
+        result = NpcVoiceResult(
+            npc_id=packet_copy["npc"]["id"],
+            npc_name=packet_copy["npc"]["name"],
+            content_hash=key,
+            thought=validated["thought"],
+            affinity_event=affinity_event,
+            model=getattr(thought_response, "model", None) or thought_model,
+            usage=Usage(
+                prompt_tokens=(
+                    thought_usage.prompt_tokens
+                    + classification_usage.prompt_tokens
+                ),
+                completion_tokens=(
+                    thought_usage.completion_tokens
+                    + classification_usage.completion_tokens
+                ),
+                total_tokens=(
+                    thought_usage.total_tokens
+                    + classification_usage.total_tokens
+                ),
+            ),
+            latency_seconds=round(time.perf_counter() - started, 4),
+            source_turn_id=packet_copy["beat"]["id"],
+            counterparty_id=packet_copy["relationship"]["counterpartyId"],
+            relationship_evidence_summary=(
+                packet_copy["beat"]["relationshipEvidence"]["summary"]
+                if packet_copy["beat"]["relationshipEvidence"] is not None
+                else ""
+            ),
+            packet_hash=canonical_hash(packet_copy),
+            module=packet_copy["scene"]["module"],
+            location_id=packet_copy["scene"]["locationId"],
+            current_goal_reference=packet_copy["working"]["currentGoal"],
+            open_question=packet_copy["working"]["openQuestion"],
+            mood_tags=tuple(packet_copy["working"]["moodTags"]),
+            expires_after_turn=packet_copy["working"]["expiresAfterTurn"],
+            scene_id=(
+                "%s|%s"
+                % (
+                    packet_copy["scene"]["module"],
+                    packet_copy["scene"]["locationId"],
+                )
+            ),
+            generation_token=generation_token,
+            completed_at=time.perf_counter(),
+            cacheable=classification_complete,
+        )
+        if (
+            classification_complete
+            and cache_result
+            and _GENERATIONS.active(generation_token)
+        ):
+            self.cache.put(key, result)
+        return result
+
+    def think_best_effort(
+        self,
+        packet: Mapping[str, Any],
+        *,
+        deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+    ) -> NpcVoiceBatch:
+        return self.think_batch_best_effort(
+            (packet,), deadline_seconds=deadline_seconds
+        )
+
+    def think_batch_best_effort(
+        self,
+        packets: Iterable[Mapping[str, Any]],
+        *,
+        deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+    ) -> NpcVoiceBatch:
+        """Run up to four logical NPC calls without waiting past the merge cap."""
+        batch_started = time.perf_counter()
+        candidates = list(packets)[:MAX_LOGICAL_NPCS]
+        token = _GENERATIONS.issue()
+        budget = _RequestBudget(deadline_seconds)
+        provider = ""
+        batch_id = ""
+        validated_packets = []
+        try:
+            provider = model_config.get_provider()
+            for packet in candidates:
+                try:
+                    packet_copy = validate_packet(packet)
+                    candidate_batch_id = packet_copy["beat"]["id"]
+                    if batch_id and candidate_batch_id != batch_id:
+                        raise ValueError("mixed batch IDs")
+                    batch_id = candidate_batch_id
+                    validated_packets.append(packet_copy)
+                    self._record(
+                        kind="candidate",
+                        disposition="selected",
+                        batch_id=batch_id,
+                        npc_id=packet_copy["npc"]["id"],
+                    )
+                except Exception:
+                    self._record(
+                        kind="candidate",
+                        disposition="invalid_packet",
+                        batch_id=batch_id,
+                    )
+
+            indexed_results: Dict[int, NpcVoiceResult] = {}
+            futures = {}
+            for index, packet_copy in enumerate(validated_packets):
+                npc_id = packet_copy["npc"]["id"]
+                key = self._cache_key(packet_copy, provider)
+                cached = self.cache.get(key)
+                if cached is not None:
+                    result = replace(
+                        cached,
+                        usage=Usage(),
+                        latency_seconds=0.0,
+                        cached=True,
+                        generation_token=token,
+                        completed_at=time.perf_counter(),
+                    )
+                    indexed_results[index] = result
+                    self._record(
+                        kind="cache",
+                        disposition="hit",
+                        batch_id=batch_id,
+                        npc_id=npc_id,
+                        provider=provider,
+                        model=result.model,
+                    )
+                    continue
+
+                if not _WORKER_SLOTS.acquire(blocking=False):
+                    self._record(
+                        kind="candidate",
+                        disposition="worker_unavailable",
+                        batch_id=batch_id,
+                        npc_id=npc_id,
+                    )
+                    continue
+
+                def run_and_release(
+                    selected_packet: Mapping[str, Any] = packet_copy,
+                ) -> NpcVoiceResult:
+                    try:
+                        return self._think_with_provider(
+                            selected_packet,
+                            provider,
+                            budget=budget,
+                            generation_token=token,
+                            cache_result=False,
+                        )
+                    finally:
+                        _WORKER_SLOTS.release()
+
+                try:
+                    future = _EXECUTOR.submit(run_and_release)
+                    futures[future] = index
+                except Exception:
+                    _WORKER_SLOTS.release()
+                    self._record(
+                        kind="candidate",
+                        disposition="submission_failure",
+                        batch_id=batch_id,
+                        npc_id=npc_id,
+                    )
+
+            done, pending = wait(tuple(futures), timeout=budget.remaining())
+            for future in done:
+                index = futures[future]
+                npc_id = validated_packets[index]["npc"]["id"]
+                try:
+                    result = future.result()
+                except Exception:
+                    self._record(
+                        kind="candidate",
+                        disposition="future_failure",
+                        batch_id=batch_id,
+                        npc_id=npc_id,
+                    )
+                    continue
+                if (
+                    result.generation_token != token
+                    or result.completed_at > budget.deadline
+                    or not _GENERATIONS.active(token)
+                ):
+                    self._record(
+                        kind="candidate",
+                        disposition="late_result_rejected",
+                        batch_id=batch_id,
+                        npc_id=npc_id,
+                    )
+                    continue
+                indexed_results[index] = result
+
+            for future in pending:
+                index = futures[future]
+                self._record(
+                    kind="candidate",
+                    disposition="deadline_omission",
+                    batch_id=batch_id,
+                    npc_id=validated_packets[index]["npc"]["id"],
+                )
+
+            _GENERATIONS.expire(token)
+            ordered = tuple(
+                indexed_results[index]
+                for index in sorted(indexed_results)
+            )
+            for result in ordered:
+                if not result.cached and result.cacheable:
+                    self.cache.put(result.content_hash, result)
+                if result.affinity_event is not None:
+                    self._record(
+                        kind="event",
+                        disposition="staged",
+                        batch_id=batch_id,
+                        npc_id=result.npc_id,
+                    )
+                self._record(
+                    kind="merge",
+                    disposition="merged",
+                    batch_id=batch_id,
+                    npc_id=result.npc_id,
+                )
+            self._record(
+                kind="batch",
+                disposition="complete",
+                batch_id=batch_id,
+                latency_seconds=time.perf_counter() - batch_started,
+                provider=provider,
+                candidate_count=len(validated_packets),
+                physical_request_count=budget.count,
+                merged_count=len(ordered),
+            )
+            return NpcVoiceBatch(
+                batch_id=batch_id,
+                results=ordered,
+                generation_token=token,
+                candidate_count=len(validated_packets),
+                physical_request_count=budget.count,
+                telemetry=self.telemetry,
+            )
+        except Exception:
+            _GENERATIONS.expire(token)
+            self._record(
+                kind="batch",
+                disposition="batch_failure",
+                batch_id=batch_id,
+                latency_seconds=time.perf_counter() - batch_started,
+                provider=provider,
+                candidate_count=len(validated_packets),
+                physical_request_count=budget.count,
+            )
+            return NpcVoiceBatch(
+                batch_id=batch_id,
+                results=(),
+                generation_token=token,
+                candidate_count=len(validated_packets),
+                physical_request_count=budget.count,
+                telemetry=self.telemetry,
+            )
+        finally:
+            _GENERATIONS.expire(token)

--- a/core/npc/voice_service.py
+++ b/core/npc/voice_service.py
@@ -572,7 +572,9 @@ class NpcVoiceService:
                     messages=messages,
                     model=model,
                     temperature=TEMPERATURE,
-                    max_tokens=MAX_OUTPUT_TOKENS,
+                    # No max_tokens/max_completion_tokens on any call: the gpt-5.x
+                    # default (luna) rejects max_tokens with a 400. Output length is
+                    # bounded by the client-side contract validation instead.
                     retry_attempt=attempt,
                     **config,
                 )

--- a/core/npc/voice_service.py
+++ b/core/npc/voice_service.py
@@ -24,6 +24,7 @@ from core.npc.voice_contracts import (
     TASK_ID,
     ThoughtContractError,
     canonical_hash,
+    gemini_response_schema,
     validate_packet,
     validate_thought_response,
 )
@@ -252,6 +253,9 @@ class NpcVoiceResult:
     model: str
     usage: Usage
     latency_seconds: float
+    say: Optional[str] = None
+    do: Optional[str] = None
+    want: Optional[str] = None
     cached: bool = False
     source_turn_id: str = ""
     counterparty_id: str = ""
@@ -400,17 +404,28 @@ def build_classification_messages(
 
 
 def _config_for_provider(provider: str) -> Dict[str, Any]:
+    # OpenAI/legacy use plain JSON mode (json_object) + client-side
+    # validate_thought_response + one bounded retry. We deliberately do NOT use
+    # OpenAI strict json_schema here: the enriched contract makes say/do/want
+    # OPTIONAL (strict mode requires every property), and the same callsite also
+    # serves the affinity classifier which returns only thought + affinityEvent.
+    # Gemini needs response_schema or it silently drops the enriched fields
+    # (T014-class bug). Never attach response_schema on the OpenAI path (400).
     if provider == "openai":
-        selected = model_config.NPC_VOICE_T105_OPENAI_LUNA_NONE
+        selected = copy.deepcopy(model_config.NPC_VOICE_T105_OPENAI_LUNA_NONE)
+        selected["response_format"] = {"type": "json_object"}
     elif provider == "gemini":
-        selected = model_config.NPC_VOICE_T105_GEMINI_FLASHLITE_LOW
+        selected = copy.deepcopy(model_config.NPC_VOICE_T105_GEMINI_FLASHLITE_LOW)
+        selected["response_schema"] = gemini_response_schema()
     elif provider == "lmstudio":
-        selected = model_config.NPC_VOICE_T105_LMSTUDIO
+        selected = copy.deepcopy(model_config.NPC_VOICE_T105_LMSTUDIO)
+        selected["response_format"] = None
     elif provider == "legacy":
-        selected = model_config.NPC_VOICE_T105_LEGACY
+        selected = copy.deepcopy(model_config.NPC_VOICE_T105_LEGACY)
+        selected["response_format"] = {"type": "json_object"}
     else:
         raise ValueError("unsupported T105 provider: %s" % provider)
-    return copy.deepcopy(selected)
+    return selected
 
 
 class NpcVoiceService:
@@ -695,6 +710,9 @@ class NpcVoiceService:
             content_hash=key,
             thought=validated["thought"],
             affinity_event=affinity_event,
+            say=validated.get("say"),
+            do=validated.get("do"),
+            want=validated.get("want"),
             model=getattr(thought_response, "model", None) or thought_model,
             usage=Usage(
                 prompt_tokens=(

--- a/main.py
+++ b/main.py
@@ -1644,6 +1644,7 @@ def _assemble_validation_messages(
     candidate_response,
     compress_prefix=None,
     srd_context=None,
+    npc_voice_batch=None,
 ):
     """Compress context first, then preserve the raw intent/candidate pair."""
     prefix = [dict(message) for message in validation_prefix]
@@ -1651,10 +1652,21 @@ def _assemble_validation_messages(
         prefix = compress_prefix(prefix)
     if srd_context:
         prefix.append({"role": "system", "content": srd_context})
-    return prefix + [
+    messages = prefix + [
         {"role": "user", "content": str(raw_user_input or "")},
         {"role": "assistant", "content": candidate_response},
     ]
+    if npc_voice_batch is not None:
+        try:
+            from core.npc.voice_context import inject_voice_context
+
+            messages = inject_voice_context(messages, npc_voice_batch)
+        except Exception as voice_error:
+            debug(
+                f"T105 validator guidance skipped: {type(voice_error).__name__}",
+                category="ai_validation",
+            )
+    return messages
 
 
 def _normalize_semantic_rejection_reason(reason):
@@ -1680,6 +1692,7 @@ def validate_ai_response(
     conversation_history,
     party_tracker_data,
     srd_context=None,
+    npc_voice_batch=None,
 ):
     print("DEBUG: NPC validation running...")
     status_validating()
@@ -1978,18 +1991,31 @@ def validate_ai_response(
         user_input,
         response_to_validate,
         srd_context=srd_context,
+        npc_voice_batch=npc_voice_batch,
     )
+    validation_messages_for_diagnostics = validation_messages_to_send
+    if npc_voice_batch is not None:
+        try:
+            from core.npc.voice_context import redact_voice_context
+
+            validation_messages_for_diagnostics = redact_voice_context(
+                validation_messages_to_send
+            )
+        except Exception:
+            validation_messages_for_diagnostics = [
+                {"role": "system", "content": "Private NPC guidance: [redacted]"}
+            ]
 
     if '"action": "createNewModule"' in response_to_validate:
         debug(
             "VALIDATION: createNewModule raw intent/candidate pair isolated",
             category="ai_validation",
         )
-    
+
     # Export validation messages for debugging
     os.makedirs("debug/api_captures", exist_ok=True)
     with open("debug/api_captures/main_validation_messages_to_api.json", "w", encoding="utf-8") as f:
-        json.dump(validation_messages_to_send, f, indent=2, ensure_ascii=False)
+        json.dump(validation_messages_for_diagnostics, f, indent=2, ensure_ascii=False)
     print(f"DEBUG: [MAIN VALIDATION] Exported validation messages to debug/api_captures/main_validation_messages_to_api.json")
     
     max_validation_retries = 3
@@ -2024,7 +2050,7 @@ def validate_ai_response(
         # Log API call to master log
         try:
             from utils.api_logger import log_api_call
-            log_api_call("validation", validation_messages_to_send, validation_result,
+            log_api_call("validation", validation_messages_for_diagnostics, validation_result,
                         metadata={"attempt": attempt+1, "max_retries": max_validation_retries})
         except Exception as e:
             print(f"[API_LOG] Warning: Failed to log validation call: {e}")
@@ -4555,6 +4581,7 @@ def get_ai_response(
     validation_retry_count=0,
     *,
     _skip_pending_publication_delivery=False,
+    npc_voice_batch=None,
 ):
     global should_inject_creation_prompt
     # This is the centralized terminal/web provider boundary. A transition
@@ -4694,10 +4721,31 @@ def get_ai_response(
                 temp_file.unlink()
             except OSError as cleanup_error:
                 print(f"WARNING: Could not remove compression input: {cleanup_error}")
-    
+
+    # T105 guidance is request-local and is inserted only after compression.
+    # A missing, invalid, disabled, or failed batch returns the exact existing
+    # message list unchanged.
+    messages_for_diagnostics = messages_to_send
+    if npc_voice_batch is not None:
+        try:
+            from core.npc.voice_context import (
+                inject_voice_context,
+                redact_voice_context,
+            )
+
+            messages_to_send = inject_voice_context(
+                messages_to_send, npc_voice_batch
+            )
+            messages_for_diagnostics = redact_voice_context(messages_to_send)
+        except Exception as voice_error:
+            debug(
+                f"T105 DM guidance skipped: {type(voice_error).__name__}",
+                category="ai_routing",
+            )
+
     # Export main conversation messages for debugging
     with open("main_conversation_messages_to_api.json", "w", encoding="utf-8") as f:
-        json.dump(messages_to_send, f, indent=2, ensure_ascii=False)
+        json.dump(messages_for_diagnostics, f, indent=2, ensure_ascii=False)
     print(f"DEBUG: [MAIN CONVERSATION] Exported conversation messages to main_conversation_messages_to_api.json")
     
     # Generate response with selected model (unified path -- provider-agnostic).
@@ -4739,7 +4787,7 @@ def get_ai_response(
     # Log API call to master log
     try:
         from utils.api_logger import log_api_call
-        log_api_call("main_dm", messages_to_send, response,
+        log_api_call("main_dm", messages_for_diagnostics, response,
                     metadata={"temperature": TEMPERATURE, "retry_count": validation_retry_count, "provider": MODEL_PROVIDER})
     except Exception as e:
         print(f"[API_LOG] Warning: Failed to log main DM call: {e}")
@@ -6091,14 +6139,36 @@ def main_game_loop():
         conversation_history.append({"role": "user", "content": user_input_with_note})
         save_conversation_history(conversation_history)
 
+        # Run T105 once per substantive player beat. The feature is default-off,
+        # and every composition/provider/validation failure collapses to an
+        # empty immutable batch without changing the authoritative turn.
+        npc_voice_batch = None
+        if getattr(config, "NPC_VOICE_ENABLED", False) is True:
+            try:
+                from core.npc.voice_context import run_ooc_voice_stage
+
+                npc_voice_batch = run_ooc_voice_stage(
+                    party_tracker_data=party_tracker_data,
+                    player_name=player_name_actual,
+                    raw_input=user_input_text,
+                    location_data=location_data,
+                    conversation_prefix=conversation_history[:-1],
+                    path_manager=path_manager,
+                )
+            except Exception as voice_error:
+                debug(
+                    f"T105 OOC stage skipped: {type(voice_error).__name__}",
+                    category="ai_routing",
+                )
+
         validation_prefix_length = len(conversation_history)
         retry_count = 0
         previous_semantic_rejection = None
         consecutive_semantic_rejections = 0
-        valid_response_received = False 
+        valid_response_received = False
         ai_response_content = None
         approved_transition_plan = None
-    
+
         while retry_count < 5 and not valid_response_received:
             # Authorization belongs only to this candidate response. A retry
             # must obtain a new plan from the current atlas/evidence snapshot.
@@ -6108,6 +6178,7 @@ def main_game_loop():
                 ai_response_content = get_ai_response(
                     conversation_history,
                     validation_retry_count=retry_count,
+                    npc_voice_batch=npc_voice_batch,
                 )
             except Exception as response_error:
                 error(
@@ -6336,8 +6407,9 @@ def main_game_loop():
                 conversation_history,
                 party_tracker_data,
                 srd_context=turn_srd_context,
+                npc_voice_batch=npc_voice_batch,
             )
-        
+
             # Unpack the validation result tuple
             is_valid = False
             validation_reason = ""
@@ -6369,7 +6441,27 @@ def main_game_loop():
                     )
                 )
                 save_conversation_history(conversation_history)
-            
+
+                # T105 relationship events are staged until this exact T067
+                # acceptance boundary. Failed candidates never reach this
+                # best-effort, idempotent sidecar commit.
+                if npc_voice_batch is not None:
+                    try:
+                        from core.npc.voice_context import (
+                            commit_accepted_ooc_voice_batch,
+                        )
+
+                        commit_accepted_ooc_voice_batch(
+                            npc_voice_batch,
+                            party_tracker_data,
+                        )
+                    except Exception as voice_commit_error:
+                        debug(
+                            f"T105 accepted event skipped: "
+                            f"{type(voice_commit_error).__name__}",
+                            category="ai_routing",
+                        )
+
                 # SIMPLIFIED ARCHITECTURE: process_ai_response now handles ALL complexity internally.
                 # This includes:
                 # - Standard turn processing

--- a/model_config.py
+++ b/model_config.py
@@ -996,9 +996,13 @@ NPC_PROFILE_T107_LEGACY = {"model": "gpt-4.1-mini-2025-04-14"}
 NPC_PROFILE_T107_LMSTUDIO = {"model": "local-model"}
 
 # Feature flag: gates the NPC voice injection wiring in main.py/combat_manager.py.
-# Default OFF until all validation gates pass; flipped ON at ship (owner ship-on
-# directive). Defined here so it reaches every build via config.py's star-import.
-NPC_VOICE_ENABLED = False
+# Shipped ON (owner ship-on directive) after all validation gates passed: full
+# tests/npc suite 104/104, real headless OOC acceptance (say/do/want reach the DM
+# and are inlined, redacted from logs/history), combat-lens voices validated, and
+# lifecycle/save-restore integration green. Every stage is fail-open, so a voice
+# failure never blocks or corrupts a turn. Defined here so it reaches every build
+# via config.py's star-import.
+NPC_VOICE_ENABLED = True
 
 # --- Model Routing Settings ---
 ENABLE_INTELLIGENT_ROUTING = True                        # Enable/disable action-based model routing

--- a/model_config.py
+++ b/model_config.py
@@ -977,6 +977,29 @@ NPC_COHERENCE_T104_LMSTUDIO = {"model": "local-model"}
 # it. ON: the pass is fail-closed + heal-forward so shipping enabled is safe.
 ENABLE_NPC_COHERENCE_REPAIR = True
 
+# ----- T105 NPC Voice (+ isolated affinity classifier) & T107 NPC Profile Seed -----
+# Per-NPC "voice" micro-model agents (NPC_VOICE_ENABLED). These are per-NPC,
+# per-relevant-turn micro calls, so OpenAI uses the CHEAPEST luna tier. Both the
+# voice/affinity call (T105) and the one-time profile seed (T107) share the same
+# cheap tier per provider. Temperature/output-cap stay at the callsite; the Gemini
+# response_schema is supplied by the service from its own contract (kept out of here
+# to avoid a model_config <-> core.npc import cycle). T105/T107 are distinct from
+# main's T104 (NPC cross-area coherence), a different feature.
+NPC_VOICE_T105_OPENAI_LUNA_NONE = copy.deepcopy(OPENAI_GPT56_LUNA_NONE)
+NPC_VOICE_T105_GEMINI_FLASHLITE_LOW = {"model": "gemini-3.1-flash-lite-preview", "thinking_level": "low"}
+NPC_VOICE_T105_LEGACY = {"model": "gpt-4.1-mini-2025-04-14"}
+NPC_VOICE_T105_LMSTUDIO = {"model": "local-model"}
+
+NPC_PROFILE_T107_OPENAI_LUNA_NONE = copy.deepcopy(OPENAI_GPT56_LUNA_NONE)
+NPC_PROFILE_T107_GEMINI_FLASHLITE_LOW = {"model": "gemini-3.1-flash-lite-preview", "thinking_level": "low"}
+NPC_PROFILE_T107_LEGACY = {"model": "gpt-4.1-mini-2025-04-14"}
+NPC_PROFILE_T107_LMSTUDIO = {"model": "local-model"}
+
+# Feature flag: gates the NPC voice injection wiring in main.py/combat_manager.py.
+# Default OFF until all validation gates pass; flipped ON at ship (owner ship-on
+# directive). Defined here so it reaches every build via config.py's star-import.
+NPC_VOICE_ENABLED = False
+
 # --- Model Routing Settings ---
 ENABLE_INTELLIGENT_ROUTING = True                        # Enable/disable action-based model routing
 MAX_VALIDATION_RETRIES = 1                              # Retry with full model after this many validation failures

--- a/model_registry.py
+++ b/model_registry.py
@@ -568,6 +568,30 @@ _declare(
     ),
     note="Classic-build NPC coherence repair is enabled at the reviewed tip default.",
 )
+_declare(
+    "T105",
+    _profiles(
+        "NPC_VOICE_T105_OPENAI_LUNA_NONE",
+        "NPC_VOICE_T105_GEMINI_FLASHLITE_LOW",
+        "NPC_VOICE_T105_LEGACY",
+        "NPC_VOICE_T105_LMSTUDIO",
+    ),
+    note="Per-NPC voice (+ isolated affinity classifier, same config) micro call, "
+         "gated by NPC_VOICE_ENABLED. OpenAI on cheapest luna|none (per-NPC per-turn "
+         "micro tier). Distinct from T104 (NPC cross-area coherence). The Gemini "
+         "response_schema is supplied by the service (core/npc/voice_service.py).",
+)
+_declare(
+    "T107",
+    _profiles(
+        "NPC_PROFILE_T107_OPENAI_LUNA_NONE",
+        "NPC_PROFILE_T107_GEMINI_FLASHLITE_LOW",
+        "NPC_PROFILE_T107_LEGACY",
+        "NPC_PROFILE_T107_LMSTUDIO",
+    ),
+    note="One-time per-NPC profile seed (structured behavior profile) for the NPC "
+         "voice system, gated by NPC_VOICE_ENABLED. OpenAI on cheapest luna|none.",
+)
 
 
 def _build_bindings():
@@ -580,16 +604,17 @@ def _build_bindings():
 
 
 CALLSITE_BINDINGS: Mapping[str, CallsiteBinding] = _build_bindings()
-# Reviewed source inventory: 75 register_callsite IDs plus enabled T104.
-# Keep this independent from _DECLARATIONS so deleting/adding a binding cannot
-# make the expected set silently redefine itself.
+# Reviewed source inventory: 75 register_callsite IDs plus enabled T104, plus the
+# NPC-voice family T105 (voice+affinity) and T107 (profile seed). Keep this
+# independent from _DECLARATIONS so deleting/adding a binding cannot make the
+# expected set silently redefine itself.
 REGISTERED_TASK_IDS = tuple(
     "T012 T013 T014 T015 T016 T017 T018 T019 T020 T021 T022 T023 T024 T025 "
     "T026 T027 T028 T029 T030 T031 T032 T033 T034 T035 T036 T037 T038 T039 "
     "T040 T041 T042 T043 T044 T045 T046 T047 T048 T049 T050 T051 T052 T053 "
     "T054 T059 T063 T064 T065 T066 T067 T077 T078 T079 T081 T082 T083 T084 "
     "T085 T086 T087 T088 T089 T090 T091 T092 T093 T094 T095 T096 T097 T098 "
-    "T099 T100 T101 T102 T103".split()
+    "T099 T100 T101 T102 T103 T105 T107".split()
 )
 EXPECTED_TASK_IDS = tuple(sorted(REGISTERED_TASK_IDS + ("T104",)))
 

--- a/prompts/npc/npc_affinity_t105.txt
+++ b/prompts/npc/npc_affinity_t105.txt
@@ -1,0 +1,20 @@
+npc-affinity-prompt/v1
+
+You are a private relationship-event classifier. Return JSON only with exactly
+two keys: thought and affinityEvent.
+
+The user message contains exactly one relationshipEvidence object from one
+accepted player/DM pair. Classify only its summary. You have no access to the
+current unresolved player input and must not infer any other beat. Set
+affinityEvent to null when that accepted pair has no clear consequential
+relationship event; ordinary neutral questions must remain null.
+
+When an event is warranted, its actor, target, and witnessed value must exactly
+match relationshipEvidence. eventType must use the response enum. Positive
+types require magnitude 1 through 3; negative types require magnitude -3
+through -1. Set thought to one short private reaction to this evidence; it is
+contract padding and is not used as current-turn NPC guidance. Return no prose
+outside the JSON object.
+
+Allowed eventType values: abandon, betray, deceive, disrespect, give, harm,
+heal, honor, protect, rescue, share, support, threaten, trust.

--- a/prompts/npc/npc_profile_seed_t107.txt
+++ b/prompts/npc/npc_profile_seed_t107.txt
@@ -1,0 +1,15 @@
+npc-profile-seed-prompt/v1
+
+You privately compress supplied authoritative NPC sheet and lifecycle facts into one
+structured behavior profile. Return exactly one JSON object with only these keys:
+voice, goals, fears, values, preferences, boundaries, conflictStyle,
+initiativeTendency, riskTolerance, protectionPriorities, retreatRules, arcSeeds.
+
+Use only facts present in the supplied source. Compress, quote, or leave optional fields
+empty. Never invent a secret, promise, item, allegiance, quest status, relationship,
+world event, or completed action. goals and values must each contain at least one grounded
+entry. arcSeeds may contain no more than two source-grounded tensions or objectives; an
+arc seed is advisory and cannot assert plot progress. initiativeTendency must be reserved,
+balanced, or proactive. riskTolerance must be cautious, measured, or bold.
+
+Return JSON only, with no prose, markdown, score, or player-facing language.

--- a/prompts/npc/npc_voice_t105.txt
+++ b/prompts/npc/npc_voice_t105.txt
@@ -1,20 +1,33 @@
-npc-voice-prompt/v2
+npc-voice-prompt/v3
 
 You are a private behavior micro-call for one party NPC. Return JSON only with
-exactly two keys: thought and affinityEvent.
+exactly five keys: say, do, want, thought, and affinityEvent.
 
-Write one immediate, actionable, Dungeon-Master-facing thought in the focal
-NPC's own perspective, using no more than 80 words. The Dungeon Master will
-translate it into observable behavior. Never address the player directly and
-never mention scores, vectors, prompts, packets, models, or game systems. Use
-only supplied facts. Do not invent an item, actor, capability, secret, promise,
-world event, action result, or resolved outcome.
+You give the focal NPC life. Everything you return is ADVISORY input for the
+Dungeon Master, who owns the final scene: the DM will reword, trim, combine, or
+override anything that does not fit the moment or the rules. Speak in the focal
+NPC's own voice and perspective. Use only supplied facts. Never address the
+player directly and never mention scores, vectors, prompts, packets, models, or
+game systems. Do not invent an item, actor, capability, secret, promise, world
+event, action result, or resolved outcome.
 
-In COMBAT, a thought may prefer a tactic, target, rescue, retreat, or protective
-behavior, but it cannot assert legality, dice, damage, resources, or resulting
-state. In OUT_OF_COMBAT, prioritize goals, social pressure, useful items, and
-credible initiative.
+Return each key as follows:
+- say: one short line of dialogue the NPC would speak this beat, in their voice
+  (<=240 characters); or null if they would stay silent. Do not narrate; give the
+  spoken words only.
+- do: one action or intent the NPC would take this beat (<=200 characters); or
+  null if none. Describe the intent in plain terms. Never assert legality, dice,
+  damage, resources, distances, or resulting state -- the DM resolves mechanics.
+- want: the NPC's current desire or goal driving them right now (<=200
+  characters); or null if nothing salient. Ground it in their profile, bonds, and
+  relationship state.
+- thought: one private, immediate, Dungeon-Master-facing line of the NPC's
+  reasoning (<=80 words). This is not shown to the player.
 
-This request is the thought portion only. Set affinityEvent to null. A separate
-isolated request owns classification of any prior accepted relationship evidence.
-Return no prose outside the JSON object.
+In COMBAT, say/do/want may prefer a tactic, target, ally to protect, rescue, or
+retreat, but still assert no mechanics. In OUT_OF_COMBAT, prioritize goals, social
+pressure, useful items, and credible initiative.
+
+This request is the say/do/want/thought portion only. Set affinityEvent to null.
+A separate isolated request owns classification of any prior accepted relationship
+evidence. Return no prose outside the JSON object.

--- a/prompts/npc/npc_voice_t105.txt
+++ b/prompts/npc/npc_voice_t105.txt
@@ -1,0 +1,20 @@
+npc-voice-prompt/v2
+
+You are a private behavior micro-call for one party NPC. Return JSON only with
+exactly two keys: thought and affinityEvent.
+
+Write one immediate, actionable, Dungeon-Master-facing thought in the focal
+NPC's own perspective, using no more than 80 words. The Dungeon Master will
+translate it into observable behavior. Never address the player directly and
+never mention scores, vectors, prompts, packets, models, or game systems. Use
+only supplied facts. Do not invent an item, actor, capability, secret, promise,
+world event, action result, or resolved outcome.
+
+In COMBAT, a thought may prefer a tactic, target, rescue, retreat, or protective
+behavior, but it cannot assert legality, dice, damage, resources, or resulting
+state. In OUT_OF_COMBAT, prioritize goals, social pressure, useful items, and
+credible initiative.
+
+This request is the thought portion only. Set affinityEvent to null. A separate
+isolated request owns classification of any prior accepted relationship evidence.
+Return no prose outside the JSON object.

--- a/schemas/npc_agent_state_schema.json
+++ b/schemas/npc_agent_state_schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "npc-agent-state/v1",
+  "title": "NPC Agent State Sidecar v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "revision", "identities", "profiles", "relationships", "working", "lifecycle", "migrations"],
+  "properties": {
+    "schemaVersion": {"const": 1},
+    "revision": {"type": "integer", "minimum": 0},
+    "identities": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$": {"$ref": "#/$defs/identity"}
+      }
+    },
+    "profiles": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$": {"$ref": "#/$defs/profile"}
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[0-9a-f-]{36}\\|[0-9a-f-]{36}$": {"$ref": "#/$defs/relationship"}
+      }
+    },
+    "working": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$": {"$ref": "#/$defs/workingState"}
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$": {"$ref": "#/$defs/lifecycleState"}
+      }
+    },
+    "migrations": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^companion-memory-v1\\|[0-9a-f-]{36}$": {"$ref": "#/$defs/migration"}
+      }
+    }
+  },
+  "$defs": {
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "displayName", "aliases", "sheetPath", "identitySeed", "active", "lastModule", "lastLocationId"],
+      "properties": {
+        "kind": {"enum": ["npc", "player"]},
+        "displayName": {"type": "string", "minLength": 1, "maxLength": 100},
+        "aliases": {"type": "array", "maxItems": 32, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 100}},
+        "sheetPath": {"type": "string", "minLength": 1, "maxLength": 500},
+        "identitySeed": {"type": "string", "minLength": 1, "maxLength": 500},
+        "active": {"type": "boolean"},
+        "lastModule": {"type": "string", "maxLength": 160},
+        "lastLocationId": {"type": "string", "maxLength": 120}
+      }
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profileVersion", "sourceHash", "voice", "goals", "fears", "values", "preferences", "boundaries", "conflictStyle", "initiativeTendency", "riskTolerance", "protectionPriorities", "retreatRules", "arcSeeds"],
+      "properties": {
+        "profileVersion": {"const": 1},
+        "sourceHash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "voice": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["cadence", "diction", "taboos"],
+          "properties": {
+            "cadence": {"type": "string", "maxLength": 120},
+            "diction": {"type": "string", "maxLength": 120},
+            "taboos": {"type": "array", "maxItems": 3, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 80}}
+          }
+        },
+        "goals": {"type": "array", "minItems": 1, "maxItems": 3, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 180}},
+        "fears": {"type": "array", "maxItems": 3, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 180}},
+        "values": {"type": "array", "minItems": 1, "maxItems": 5, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 120}},
+        "preferences": {"type": "array", "maxItems": 5, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 120}},
+        "boundaries": {"type": "array", "maxItems": 5, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 160}},
+        "conflictStyle": {"type": "string", "maxLength": 160},
+        "initiativeTendency": {"type": "string", "enum": ["reserved", "balanced", "proactive"]},
+        "riskTolerance": {"type": "string", "enum": ["cautious", "measured", "bold"]},
+        "protectionPriorities": {"type": "array", "maxItems": 3, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 120}},
+        "retreatRules": {"type": "array", "maxItems": 3, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 160}},
+        "arcSeeds": {"type": "array", "maxItems": 2, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 180}}
+      }
+    },
+    "vector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trust", "power", "intimacy", "fear", "respect"],
+      "properties": {
+        "trust": {"type": "number", "minimum": -1, "maximum": 1},
+        "power": {"type": "number", "minimum": -1, "maximum": 1},
+        "intimacy": {"type": "number", "minimum": 0, "maximum": 1},
+        "fear": {"type": "number", "minimum": 0, "maximum": 1},
+        "respect": {"type": "number", "minimum": -1, "maximum": 1}
+      }
+    },
+    "delta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trust", "power", "intimacy", "fear", "respect"],
+      "properties": {
+        "trust": {"type": "number", "minimum": -1, "maximum": 1},
+        "power": {"type": "number", "minimum": -1, "maximum": 1},
+        "intimacy": {"type": "number", "minimum": -1, "maximum": 1},
+        "fear": {"type": "number", "minimum": -1, "maximum": 1},
+        "respect": {"type": "number", "minimum": -1, "maximum": 1}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "eventId", "actorId", "targetId", "actor", "target", "eventType", "magnitude", "witnessed", "applied", "delta", "summary", "sourceTurnId", "promptVersion", "packetHash", "gameDay", "module", "locationId", "topicIds", "unresolved", "sourceHash"],
+      "properties": {
+        "kind": {"enum": ["typedEvent", "legacyEvidence"]},
+        "eventId": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "actorId": {"type": "string", "minLength": 1, "maxLength": 240},
+        "targetId": {"type": "string", "minLength": 1, "maxLength": 240},
+        "actor": {"type": "string", "minLength": 1, "maxLength": 100},
+        "target": {"type": "string", "minLength": 1, "maxLength": 100},
+        "eventType": {"anyOf": [{"type": "null"}, {"enum": ["abandon", "betray", "deceive", "disrespect", "give", "harm", "heal", "honor", "protect", "rescue", "share", "support", "threaten", "trust"]}]},
+        "magnitude": {"type": "integer", "minimum": 0, "maximum": 3},
+        "witnessed": {"type": "boolean"},
+        "applied": {"type": "boolean"},
+        "delta": {"$ref": "#/$defs/delta"},
+        "summary": {"type": "string", "minLength": 1, "maxLength": 240},
+        "sourceTurnId": {"type": "string", "minLength": 1, "maxLength": 120},
+        "promptVersion": {"type": "string", "maxLength": 80},
+        "packetHash": {"type": "string", "pattern": "^$|^[0-9a-f]{64}$"},
+        "gameDay": {"anyOf": [{"type": "null"}, {"type": "integer", "minimum": 0}]},
+        "module": {"type": "string", "maxLength": 160},
+        "locationId": {"type": "string", "maxLength": 120},
+        "topicIds": {"type": "array", "maxItems": 12, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 240}},
+        "unresolved": {"type": "boolean"},
+        "sourceHash": {"type": "string", "pattern": "^$|^[0-9a-f]{64}$"}
+      }
+    },
+    "aggregateCounts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "abandon": {"type": "integer", "minimum": 0}, "betray": {"type": "integer", "minimum": 0}, "deceive": {"type": "integer", "minimum": 0}, "disrespect": {"type": "integer", "minimum": 0}, "give": {"type": "integer", "minimum": 0}, "harm": {"type": "integer", "minimum": 0}, "heal": {"type": "integer", "minimum": 0}, "honor": {"type": "integer", "minimum": 0}, "protect": {"type": "integer", "minimum": 0}, "rescue": {"type": "integer", "minimum": 0}, "share": {"type": "integer", "minimum": 0}, "support": {"type": "integer", "minimum": 0}, "threaten": {"type": "integer", "minimum": 0}, "trust": {"type": "integer", "minimum": 0}, "legacyEvidence": {"type": "integer", "minimum": 0}
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subjectId", "counterpartyId", "baseline", "current", "lastDecayDay", "evidence", "appliedEventIds", "appliedEventHistory", "aggregateCounts", "evidenceHashChain"],
+      "properties": {
+        "subjectId": {"type": "string", "minLength": 1, "maxLength": 240},
+        "counterpartyId": {"type": "string", "minLength": 1, "maxLength": 240},
+        "baseline": {"$ref": "#/$defs/vector"},
+        "current": {"$ref": "#/$defs/vector"},
+        "lastDecayDay": {"anyOf": [{"type": "null"}, {"type": "integer", "minimum": 0}]},
+        "evidence": {"type": "array", "maxItems": 256, "items": {"$ref": "#/$defs/evidence"}},
+        "appliedEventIds": {"type": "array", "maxItems": 256, "uniqueItems": true, "items": {"type": "string", "pattern": "^[0-9a-f]{64}$"}},
+        "appliedEventHistory": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "aggregateCounts": {"$ref": "#/$defs/aggregateCounts"},
+        "evidenceHashChain": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "workingState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currentPrivateIntent", "sourceTurn", "currentGoalReference", "openQuestion", "moodTags", "expiresAfterTurn", "sceneId"],
+      "properties": {
+        "currentPrivateIntent": {"type": "string", "maxLength": 300},
+        "sourceTurn": {"type": "string", "minLength": 1, "maxLength": 120},
+        "currentGoalReference": {"type": "string", "maxLength": 300},
+        "openQuestion": {"type": "string", "maxLength": 240},
+        "moodTags": {"type": "array", "maxItems": 4, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 60}},
+        "expiresAfterTurn": {"anyOf": [{"type": "null"}, {"type": "integer", "minimum": 0}]},
+        "sceneId": {"type": "string", "maxLength": 240}
+      }
+    },
+    "lifecycleEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "sourceTurnId", "module", "locationId", "cause", "departureKind", "destination", "returnHook"],
+      "properties": {
+        "kind": {"enum": ["join", "depart", "rejoin", "module"]},
+        "sourceTurnId": {"type": "string", "maxLength": 120},
+        "module": {"type": "string", "maxLength": 160},
+        "locationId": {"type": "string", "maxLength": 120},
+        "cause": {"type": "string", "maxLength": 240},
+        "departureKind": {"type": "string", "maxLength": 80},
+        "destination": {"type": "string", "maxLength": 160},
+        "returnHook": {"type": "string", "maxLength": 240},
+        "gameDay": {"anyOf": [{"type": "null"}, {"type": "integer", "minimum": 0}]},
+        "invitedBy": {"type": "string", "maxLength": 100},
+        "terms": {"type": "string", "maxLength": 240},
+        "personalObjective": {"type": "string", "maxLength": 240},
+        "redLines": {"type": "array", "maxItems": 5, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 160}},
+        "compensation": {"type": "string", "maxLength": 160},
+        "expectedDuration": {"type": "string", "maxLength": 160},
+        "priorStatus": {"enum": ["new", "active", "inactive", "unknown"]},
+        "unresolvedObligations": {"type": "array", "maxItems": 5, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 180}}
+      }
+    },
+    "lifecycleState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "events"],
+      "properties": {
+        "status": {"enum": ["active", "inactive"]},
+        "events": {"type": "array", "maxItems": 64, "items": {"$ref": "#/$defs/lifecycleEvent"}}
+      }
+    },
+    "migration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "npcId", "sourcePath", "sourceHash", "status", "legacyBehaviorHint", "migratedEvidence"],
+      "properties": {
+        "version": {"const": "companion-memory-v1"},
+        "npcId": {"type": "string", "minLength": 1, "maxLength": 240},
+        "sourcePath": {"type": "string", "minLength": 1, "maxLength": 500},
+        "sourceHash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "status": {"const": "migrated"},
+        "legacyBehaviorHint": {"type": "string", "maxLength": 500},
+        "migratedEvidence": {"type": "integer", "minimum": 0, "maximum": 256}
+      }
+    }
+  }
+}

--- a/schemas/npc_voice_response_schema.json
+++ b/schemas/npc_voice_response_schema.json
@@ -1,6 +1,42 @@
 {
   "type": "object",
   "properties": {
+    "say": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      ]
+    },
+    "do": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        }
+      ]
+    },
+    "want": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        }
+      ]
+    },
     "thought": {
       "type": "string",
       "minLength": 1,
@@ -45,7 +81,14 @@
             },
             "magnitude": {
               "type": "integer",
-              "enum": [-3, -2, -1, 1, 2, 3]
+              "enum": [
+                -3,
+                -2,
+                -1,
+                1,
+                2,
+                3
+              ]
             },
             "witnessed": {
               "type": "boolean"
@@ -63,6 +106,9 @@
       ]
     }
   },
-  "required": ["thought", "affinityEvent"],
+  "required": [
+    "thought",
+    "affinityEvent"
+  ],
   "additionalProperties": false
 }

--- a/schemas/npc_voice_response_schema.json
+++ b/schemas/npc_voice_response_schema.json
@@ -1,0 +1,68 @@
+{
+  "type": "object",
+  "properties": {
+    "thought": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 640
+    },
+    "affinityEvent": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "actor": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "target": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "eventType": {
+              "type": "string",
+              "enum": [
+                "abandon",
+                "betray",
+                "deceive",
+                "disrespect",
+                "give",
+                "harm",
+                "heal",
+                "honor",
+                "protect",
+                "rescue",
+                "share",
+                "support",
+                "threaten",
+                "trust"
+              ]
+            },
+            "magnitude": {
+              "type": "integer",
+              "enum": [-3, -2, -1, 1, 2, 3]
+            },
+            "witnessed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "actor",
+            "target",
+            "eventType",
+            "magnitude",
+            "witnessed"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "required": ["thought", "affinityEvent"],
+  "additionalProperties": false
+}

--- a/updates/save_game_manager.py
+++ b/updates/save_game_manager.py
@@ -60,6 +60,7 @@ Handles save and restore functionality for game state preservation.
 # ============================================================================
 
 import json
+import hashlib
 import os
 import shutil
 import zipfile
@@ -206,7 +207,8 @@ class SaveGameManager:
             "current_location.json", 
             "journal.json",
             "player_storage.json",
-            
+            "data/companion_memories/",
+
             # Installed SRD reference data is application-owned, not campaign
             # state. Restoring an old save must never downgrade current rules.
             "training_data.json",
@@ -297,6 +299,7 @@ class SaveGameManager:
             "modules/.module_transactions/",
             "modules/.publication_transactions/",
             "modules/.module_orphan_quarantine/",
+            "modules/.runtime_quarantine/",
             ".runtime_locks/",
             "modules/conversation_history/pending_location_transition.json",
             
@@ -308,6 +311,7 @@ class SaveGameManager:
             # Temporary files
             "*.tmp",
             "*.bak",
+            "*.lock",
             "*.backup_*",
             # NOTE: *_BU.json files are now INCLUDED in saves as they are critical
             # for the reset_campaign.py functionality
@@ -401,7 +405,76 @@ class SaveGameManager:
             return "saved_games"
         
         return f"modules/{self.current_module}/saved_games"
-    
+
+    @staticmethod
+    def _state_manifest_for_root(root: str = ".") -> List[Dict[str, Any]]:
+        """Describe private state files by fingerprint, never by contents."""
+        relative_path = "data/companion_memories/npc_agent_state.json"
+        sidecar_path = os.path.join(root, relative_path)
+        if not os.path.isfile(sidecar_path):
+            return []
+        try:
+            with open(sidecar_path, "rb") as handle:
+                raw = handle.read()
+        except OSError:
+            return []
+        try:
+            parsed = json.loads(raw.decode("utf-8"))
+            schema_version = (
+                parsed.get("schemaVersion", -1)
+                if isinstance(parsed, dict)
+                else -1
+            )
+        except (UnicodeError, ValueError, TypeError):
+            schema_version = -1
+        return [
+            {
+                "path": relative_path,
+                "sha256": hashlib.sha256(raw).hexdigest(),
+                "schemaVersion": schema_version,
+                "bytes": len(raw),
+            }
+        ]
+
+    @staticmethod
+    def _validate_state_manifest(
+        save_path: str, metadata: Dict[str, Any]
+    ) -> Tuple[bool, str]:
+        """Validate every listed private state file before live mutation."""
+        manifest = metadata.get("state_manifest")
+        if manifest is None:
+            return True, ""
+        if not isinstance(manifest, list):
+            return False, "state manifest is not a list"
+        allowed_path = "data/companion_memories/npc_agent_state.json"
+        for entry in manifest:
+            if not isinstance(entry, dict) or set(entry) != {
+                "path", "sha256", "schemaVersion", "bytes"
+            }:
+                return False, "state manifest entry is malformed"
+            if entry["path"] != allowed_path:
+                return False, "state manifest path is not recognized"
+            candidate = os.path.join(save_path, allowed_path)
+            try:
+                with open(candidate, "rb") as handle:
+                    raw = handle.read()
+            except OSError:
+                return False, "listed state file is missing"
+            if len(raw) != entry["bytes"]:
+                return False, "listed state file size differs"
+            if hashlib.sha256(raw).hexdigest() != entry["sha256"]:
+                return False, "listed state file hash differs"
+            try:
+                parsed = json.loads(raw.decode("utf-8"))
+            except (UnicodeError, ValueError, TypeError):
+                return False, "listed state file is not JSON"
+            if (
+                not isinstance(parsed, dict)
+                or parsed.get("schemaVersion") != entry["schemaVersion"]
+            ):
+                return False, "listed state schema version differs"
+        return True, ""
+
     def generate_save_metadata(self, description: str = "", save_mode: str = "essential") -> Dict[str, Any]:
         """Generate metadata for a save game"""
         timestamp = datetime.now()
@@ -457,9 +530,10 @@ class SaveGameManager:
             "system_info": {
                 "save_format_version": "1.0",
                 "created_by": "NeverEndingQuest Save System",
-            }
+            },
+            "state_manifest": self._state_manifest_for_root(),
         }
-        
+
         return metadata
     
     def create_save_game(self, description: str = "", save_mode: str = "essential") -> Tuple[bool, str]:
@@ -546,7 +620,9 @@ class SaveGameManager:
             # Generate and save metadata
             metadata = self.generate_save_metadata(description, save_mode)
             metadata_path = f"{save_path}/save_metadata.json"
-            if not safe_write_json(metadata_path, metadata):
+            if not safe_write_json(
+                metadata_path, metadata, create_backup=False
+            ):
                 return False, "Failed to write save metadata"
             
             # Copy files based on save mode
@@ -605,9 +681,16 @@ class SaveGameManager:
                 "files_skipped": len(skipped_files),
                 "total_files_processed": len(copied_files) + len(skipped_files),
             }
-            
+
+            # Fingerprint the copied bytes, not a later live revision. This
+            # keeps metadata and the save payload on the exact same timeline.
+            metadata["state_manifest"] = self._state_manifest_for_root(save_path)
+
             # Save updated metadata
-            safe_write_json(metadata_path, metadata)
+            if not safe_write_json(
+                metadata_path, metadata, create_backup=False
+            ):
+                return False, "Failed to finalize save metadata"
             
             success_msg = f"Save game created successfully: {save_path}"
             success_msg += f"\nCopied {len(copied_files)} files"
@@ -732,7 +815,17 @@ class SaveGameManager:
             metadata = safe_read_json(metadata_path)
             if not metadata:
                 return False, "Could not read save game metadata"
-            
+
+            manifest_valid, manifest_error = self._validate_state_manifest(
+                save_path, metadata
+            )
+            if not manifest_valid:
+                return (
+                    False,
+                    "State manifest integrity validation failed: "
+                    f"{manifest_error}",
+                )
+
             # Create backup of current state before restoring
             backup_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
             backup_dir = (
@@ -802,6 +895,7 @@ class SaveGameManager:
             directories_to_clean = [
                 "modules/encounters/",  # Global encounters directory
                 "characters/",  # Player/NPC characters
+                "data/companion_memories/",  # Private campaign runtime state
             ]
             
             # Add module-specific directories if we have a current module
@@ -823,6 +917,14 @@ class SaveGameManager:
                         for file in os.listdir(directory):
                             file_path = os.path.join(directory, file)
                             if os.path.isfile(file_path):
+                                if directory == "data/companion_memories/":
+                                    if (
+                                        file not in {".gitkeep", ".gitignore"}
+                                        and not file.endswith(".lock")
+                                    ):
+                                        os.remove(file_path)
+                                        debug(f"FILE_OP: Removed: {file_path}", category="save_game")
+                                    continue
                                 # CRITICAL: Preserve BU files during restore
                                 if file.endswith("_BU.json"):
                                     debug(f"FILE_OP: Preserving BU file: {file_path}", category="save_game")


### PR DESCRIPTION
## What & why
Forward-ports the per-NPC "voice" micro-model system onto current main (adopting the luna callsite registry the old `npc-voice-plan` branch predated) and **enriches** it per owner directive so each companion proposes what they'd **say** (dialogue), **do** (action/intent), and **want** (desire) — plus a private thought and a typed affinity event. These are **advisory input injected into the main DM model call** (both the OOC loop and combat), which the DM **edits/inlines/overrides** — never straight-injected to output. Gives NPCs actions + desires + voice while the DM keeps final authorship.

## Model / cost
Per-NPC per-turn **micro calls on the cheapest luna tier** (`gpt-5.6-luna|none`); 4-provider registry bindings (openai/gemini/legacy/lmstudio), Gemini carries a `response_schema`. Task IDs T105 (voice+affinity) / T107 (profile seed) — distinct from main's T104. Every stage is **fail-open**: a voice failure never blocks or corrupts a turn.

## Scenarios wired
- OOC main DM loop (inject before T067) + validator
- Combat: legacy (before T045) + agentic (npc_voice_intents through the intent call) + combat validator
- Lifecycle: recruit/depart hook + module-transition; NPC relationship **sidecar** persisted, bundled into saves, private-free manifest, private runtime excluded from shared headless copies
- Phase-7 companion context cutover (active-only, departed excluded, no numeric/private leakage; flag-off byte-identical to legacy)

## Validation
- **Full `tests/npc` suite: 104/104 green**
- **Real headless OOC acceptance**: T105 fires on luna; the say/do/want block reaches the real DM call (verified in `model_captures/T067`); **32/32 injected `say` lines reworded by the DM, 0 verbatim**; redacted from api log + durable history (0 leaks); distinct per-NPC voices; fail-open
- **Combat-lens** voices validated on luna (distinct tactical say/do/want); shares the proven inject→inline→redaction mechanism
- Fixed a shipping-blocker en route: gpt-5.x rejects `max_tokens` (400) — the fail-open had hidden a fully-dead feature behind perfect-looking narration (caught by reading the api log, per the headless-acceptance doctrine)

## Notes
- Shipped **ON** by default (`NPC_VOICE_ENABLED=True`) per the owner ship-on directive; it is a per-callsite fail-open toggle.
- Not yet done: a fully-organic real-combat / module-transition **drive** (the acceptance drives stalled on module navigation, not a feature defect — combat is validated via the combat-lens stage + the shared, live-proven injection mechanism + unit tests); and a capture-based cross-model quality comparison / qwen-LM-Studio pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)