### PR TITLE
fix: quarantine dead-build residue instead of permanently bricking recovery (#167 root cause)

### DIFF
--- a/core/generators/module_stitcher.py
+++ b/core/generators/module_stitcher.py
@@ -4817,6 +4817,51 @@ Respond with JSON:
             print(f"Error getting travel narration for {module_name}: {e}")
             return {}
     
+    def _disk_fallback_module_list(self) -> List[Dict[str, Any]]:
+        """Minimal module listing derived from on-disk public module directories,
+        used only when the registry names no modules (issue #167 class). Analysis
+        is detection-only (no travel narration, no registration, no writes)."""
+        support_roots = {
+            'backups', 'campaign_archives', 'campaign_summaries',
+            'conversation_history', 'default', 'encounters', 'logs',
+        }
+        listing: List[Dict[str, Any]] = []
+        modules_dir = 'modules'
+        if not os.path.isdir(modules_dir):
+            return listing
+        for name in sorted(os.listdir(modules_dir)):
+            if name.startswith('.') or name in support_roots:
+                continue
+            if not os.path.isdir(os.path.join(modules_dir, name)):
+                continue
+            try:
+                detected = self.analyze_module(name, include_travel_narration=False)
+            except Exception as detect_error:
+                print(f"Warning: Could not analyze module {name}: {detect_error}")
+                continue
+            areas = (detected or {}).get('areas') or {}
+            if not areas:
+                continue
+            listing.append({
+                "moduleName": name,
+                "plotObjective": '',
+                "levelRange": {},
+                "areaCount": len(areas),
+                "locationCount": sum(
+                    area.get('locationCount', 0) for area in areas.values()
+                    if isinstance(area, dict)
+                ),
+                "plotPointCount": 0,
+                "addedDate": '',
+                "hasTravel": False,
+            })
+        if listing:
+            print(
+                f"[MODULES] Registry names no modules; listing {len(listing)} "
+                "module(s) found on disk."
+            )
+        return listing
+
     def get_available_modules(self) -> List[Dict[str, Any]]:
         """Get list of all available modules with basic info"""
         try:
@@ -4855,7 +4900,16 @@ Respond with JSON:
                     "addedDate": module_data.get('addedDate', ''),
                     "hasTravel": bool(module_data.get('travelNarration'))
                 })
-            
+
+            # Issue #167 class: an empty (fresh/auto-created) registry used to
+            # make the toolkit/web module list silently empty even with real
+            # modules on disk -- the same registry-shadow defect fixed in the
+            # startup scan. Fall back to a disk-derived listing so on-disk
+            # modules are never invisible; registry data stays preferred when
+            # it has entries.
+            if not module_list:
+                module_list = self._disk_fallback_module_list()
+
             return sorted(module_list, key=lambda x: x['addedDate'])
             
         except Exception as e:

--- a/utils/module_lifecycle.py
+++ b/utils/module_lifecycle.py
@@ -312,6 +312,14 @@ class ModuleLifecycleStore:
         self.staging_root = self.transaction_root / "staging"
         self.active_root = self.transaction_root / "active"
         self.resolved_root = self.transaction_root / "resolved"
+        # Evidence-preserving parking lot for unreadable/inconsistent DEAD
+        # transaction residue (issue #167 follow-through): corrupted resolved or
+        # staging debris -- e.g. journals written by the pre-#165 Windows
+        # text-mode writer -- previously made recover() INDETERMINATE forever,
+        # bricking module listing, saves, restores, builds, and resets at once.
+        # Quarantined directories are renamed here intact (never deleted, never
+        # mutated) and are ignored by recovery thereafter.
+        self.quarantine_root = self.transaction_root / "quarantined"
 
     # ------------------------------------------------------------------
     # Durable and containment primitives
@@ -514,13 +522,23 @@ class ModuleLifecycleStore:
             self._mkdir_exact(self.transaction_root, parent=self.modules_dir)
         else:
             self._require_plain_directory(self.transaction_root)
-        for root in (self.staging_root, self.active_root, self.resolved_root):
+        for root in (
+            self.staging_root,
+            self.active_root,
+            self.resolved_root,
+            self.quarantine_root,
+        ):
             if self._entry_stat(root) is None:
                 self._mkdir_exact(root, parent=self.transaction_root)
             else:
                 self._require_plain_directory(root)
 
-        for root in (self.staging_root, self.active_root, self.resolved_root):
+        for root in (
+            self.staging_root,
+            self.active_root,
+            self.resolved_root,
+            self.quarantine_root,
+        ):
             self._require_plain_directory(root)
 
     def _require_layout(self) -> None:
@@ -1747,6 +1765,29 @@ class ModuleLifecycleStore:
             raise LifecycleIndeterminateError("Active identity does not match intent")
         return intent
 
+    def _quarantine_residue(self, transaction: Path, reason: str) -> Path:
+        """Identity-bound rename of one DEAD transaction's unreadable residue
+        into quarantine_root. Same discipline as _retire: rename only, contents
+        untouched, evidence preserved for forensics. Only ever called for
+        resolved/staging debris -- never for an active transaction (an active
+        authority with unreadable state stays fail-closed, because only there
+        could the live registry be mid-mutation)."""
+        target = self.quarantine_root / transaction.name
+        if self._entry_stat(target) is not None:
+            target = self.quarantine_root / (
+                f"{transaction.name}.{uuid4().hex[:8]}"
+            )
+        source_parent = transaction.parent
+        self._replace_entry(transaction, target)
+        self._sync_directory(source_parent)
+        self._sync_directory(self.quarantine_root)
+        print(
+            "[LIFECYCLE] Quarantined unreadable dead build residue "
+            f"'{transaction.name}' ({reason}); moved to "
+            f"{target} -- module operations can proceed."
+        )
+        return target
+
     def _retire(self, transaction: Path, build_id: str) -> Path:
         resolved = self._transaction_path(self.resolved_root, build_id)
         if self._entry_stat(resolved) is not None:
@@ -2171,6 +2212,27 @@ class ModuleLifecycleStore:
             result.append(path)
         return result
 
+    def _transaction_directories_tolerant(self, root: Path) -> List[Path]:
+        """Enumerate a DEAD root (resolved/staging) for recovery, quarantining
+        alien entries instead of failing the whole pass. The strict enumerator
+        raises INDETERMINATE for ANY entry whose name is not a valid UUID (or a
+        stray file), which let a single mangled/foreign entry under dead
+        residue permanently brick recovery (issue #167 class). Alien entries in
+        dead roots are inert by construction -> rename aside intact and keep
+        going. The ACTIVE root keeps the strict enumerator."""
+        self._require_plain_directory(root)
+        result = []
+        for entry in sorted(os.scandir(root), key=lambda item: item.name):
+            path = root / entry.name
+            try:
+                _validate_uuid(entry.name)
+                self._require_plain_directory(path)
+            except (ValueError, LifecycleIndeterminateError) as exc:
+                self._quarantine_residue(path, f"alien entry: {exc}")
+                continue
+            result.append(path)
+        return result
+
     def _resolve_hidden_transaction(
         self,
         transaction: Path,
@@ -2359,21 +2421,39 @@ class ModuleLifecycleStore:
         return outcome
 
     def _recover_once(self) -> RecoveryReport:
-        """Perform one complete recovery classification pass."""
+        """Perform one complete recovery classification pass.
+
+        Per-transaction corruption in DEAD trees (resolved evidence, staging
+        candidates that never touched public state) is quarantined -- renamed
+        aside intact -- and recovery continues (issue #167: unreadable residue
+        from previously failed builds used to make this INDETERMINATE forever,
+        bricking listing/saves/builds/resets with no remediation path). Whole-
+        pass INDETERMINATE remains for anything touching LIVE shared state:
+        multiple active authorities, an unreadable ACTIVE transaction, or an
+        ambiguous live registry -- those still fail closed.
+        """
         self.ensure_layout()
-        # Resolved records are retained evidence and must remain parseable.
-        for transaction in self._transaction_directories(self.resolved_root):
-            intent = self._load_intent(transaction)
-            outcome = self._load_outcome(transaction)
-            if (
-                intent["build_id"] != transaction.name
-                or outcome.build_id != transaction.name
-                or intent["token"] != outcome.token
-                or intent["final_name"] != outcome.module_name
-            ):
-                raise LifecycleIndeterminateError(
-                    "Resolved intent/outcome identity differs"
-                )
+        # Resolved records are retained evidence and must remain parseable; an
+        # unparseable one is dead debris (its build already ended) -> quarantine.
+        for transaction in self._transaction_directories_tolerant(self.resolved_root):
+            try:
+                intent = self._load_intent(transaction)
+                outcome = self._load_outcome(transaction)
+                if (
+                    intent["build_id"] != transaction.name
+                    or outcome.build_id != transaction.name
+                    or intent["token"] != outcome.token
+                    or intent["final_name"] != outcome.module_name
+                ):
+                    raise LifecycleIndeterminateError(
+                        "Resolved intent/outcome identity differs"
+                    )
+            except OSError as exc:
+                if is_transient_filesystem_error(exc, allow_missing=False):
+                    raise  # transient blips retry via recover(), not quarantine
+                self._quarantine_residue(transaction, str(exc))
+            except (ValueError, LifecycleIndeterminateError) as exc:
+                self._quarantine_residue(transaction, str(exc))
 
         active = self._transaction_directories(self.active_root)
         if len(active) > 1:
@@ -2382,24 +2462,46 @@ class ModuleLifecycleStore:
             )
 
         outcomes: List[LifecycleOutcome] = []
-        for transaction in self._transaction_directories(self.staging_root):
-            intent = self._load_intent(transaction)
-            if intent["build_id"] != transaction.name:
-                raise LifecycleIndeterminateError("Staging identity differs")
-            phase = LifecyclePhase(intent["phase"])
-            if phase not in {
-                LifecyclePhase.BUILDING,
-                LifecyclePhase.READY,
-                LifecyclePhase.NOT_PUBLISHED,
-            }:
-                raise LifecycleIndeterminateError("Staging phase is impossible")
-            outcomes.append(
-                self._resolve_hidden_transaction(
-                    transaction,
-                    intent,
-                    reason_code="INTERRUPTED_HIDDEN_BUILD",
+        for transaction in self._transaction_directories_tolerant(self.staging_root):
+            # Staging candidates have by construction never mutated public
+            # state (publication requires promotion to active first), so an
+            # unreadable/impossible one is inert debris -> quarantine intact.
+            try:
+                intent = self._load_intent(transaction)
+                if intent["build_id"] != transaction.name:
+                    raise LifecycleIndeterminateError("Staging identity differs")
+                phase = LifecyclePhase(intent["phase"])
+                if phase not in {
+                    LifecyclePhase.BUILDING,
+                    LifecyclePhase.READY,
+                    LifecyclePhase.NOT_PUBLISHED,
+                }:
+                    raise LifecycleIndeterminateError("Staging phase is impossible")
+            except OSError as exc:
+                if is_transient_filesystem_error(exc, allow_missing=False):
+                    raise
+                self._quarantine_residue(transaction, str(exc))
+                continue
+            except (ValueError, LifecycleIndeterminateError) as exc:
+                self._quarantine_residue(transaction, str(exc))
+                continue
+            try:
+                outcomes.append(
+                    self._resolve_hidden_transaction(
+                        transaction,
+                        intent,
+                        reason_code="INTERRUPTED_HIDDEN_BUILD",
+                    )
                 )
-            )
+            except OSError as exc:
+                if is_transient_filesystem_error(exc, allow_missing=False):
+                    raise
+                # Resolution failed on the candidate itself (e.g. a corrupt
+                # candidate tree from an old failed build). It never touched
+                # public state -> quarantine intact rather than brick recovery.
+                self._quarantine_residue(transaction, str(exc))
+            except (ValueError, LifecycleIndeterminateError) as exc:
+                self._quarantine_residue(transaction, str(exc))
 
         if active:
             transaction = active[0]


### PR DESCRIPTION
The systemic root cause behind #167, traced by dual independent reviews to commit `715732d5` (July 17): `ModuleLifecycleStore.recover()` had **no remediation path** -- corrupted dead-build residue (e.g. journals written by the pre-#165 Windows text-mode writer) re-failed validation forever, and the same gate blocks **module listing, saves, restores, builds, campaign reset, and module refresh at once**. One mangled entry or stray file under `resolved/`/`staging/` was also a permanent brick via the strict UUID4 enumerator. The toolkit/web module list had the same silent registry-shadow defect fixed for the startup scan in #171.

## The fix (fail-closed preserved where it matters)
- **Quarantine, never delete**: corrupted DEAD residue (resolved evidence, staging candidates -- which by construction never mutated public state -- and alien entries) is renamed intact into `modules/.module_transactions/quarantined/` with the same identity-bound-rename discipline as `_retire`, and recovery continues. Transient OS errors still retry, never quarantine.
- **Live-state ambiguity still fails closed**: multiple active authorities, unreadable ACTIVE transaction, and every `_recover_active` live-registry classification are untouched.
- **Toolkit/web list**: disk-derived fallback (detection-only) when the registry names no modules, with a visible notice.

## Evidence (real `recover()` under the real lock, exact git-shipped module tree)
- 5-entry corrupted-residue replica (truncated JSON / CRLF-era shape / impossible phase / alien dir / stray file) -> `STABLE`, all quarantined intact, roots empty.
- Second pass `STABLE`, quarantine untouched (no over-quarantine of healthy state).
- Corrupt ACTIVE and multiple-ACTIVE -> still `INDETERMINATE`.
- End-to-end: the residue-laden replica of the #167 reporter's machine now lists both bundled adventures; toolkit list no longer silently empty.
- Suites at the same 72/15 pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)