### PR TITLE
fix(launch): P0 -- existing-party rehydration + Debug-tab diagnostics + actionable module-recovery message

### DIFF
--- a/main.py
+++ b/main.py
@@ -3131,15 +3131,30 @@ def _ordinary_action_failure_message_id(response, action, conversation_history):
     return "action-failure:" + hashlib.sha256(encoded).hexdigest()
 
 
+def _action_failure_player_message(result):
+    """Pick the CURATED player message for a terminal action error. A module
+    lifecycle recovery-required failure gets a specific, actionable message
+    (E2E 2e/W3); everything else gets the generic safe text. Selection is by the
+    whitelisted `recovery_required` boolean only -- never raw internal text."""
+    from web.shared_state import (
+        SAFE_ACTION_FAILURE_MESSAGE,
+        MODULE_RECOVERY_FAILURE_MESSAGE,
+    )
+    source_data = result.get("response_data") if isinstance(result, dict) else {}
+    if isinstance(source_data, dict) and source_data.get("recovery_required") is True:
+        return MODULE_RECOVERY_FAILURE_MESSAGE
+    return SAFE_ACTION_FAILURE_MESSAGE
+
+
 def _safe_action_failure_result(result, message_id):
     """Whitelist action-error metadata and attach the canonical player text."""
-    from web.shared_state import SAFE_ACTION_FAILURE_MESSAGE
+    player_message = _action_failure_player_message(result)
 
     source_data = result.get("response_data") if isinstance(result, dict) else {}
     if not isinstance(source_data, dict):
         source_data = {}
     response_data = {
-        "player_message": SAFE_ACTION_FAILURE_MESSAGE,
+        "player_message": player_message,
         "message_id": message_id,
     }
     for field in ("retryable", "state_changed", "recovery_required"):
@@ -3156,7 +3171,7 @@ def _safe_action_failure_result(result, message_id):
             isinstance(result, dict) and result.get("needs_update") is True
         ),
         "needs_dm_response": False,
-        "player_message": SAFE_ACTION_FAILURE_MESSAGE,
+        "player_message": player_message,
         "message_id": message_id,
         "response_data": response_data,
     }
@@ -3169,10 +3184,11 @@ def _handle_ordinary_action_failure(
     conversation_history,
 ):
     """Persist and deliver one sanitized terminal error for an accepted turn."""
-    from web.shared_state import (
-        SAFE_ACTION_FAILURE_MESSAGE,
-        emit_player_output,
-    )
+    from web.shared_state import emit_player_output
+
+    # Curated player text: specific+actionable for a lifecycle recovery-required
+    # refusal (E2E 2e/W3), generic otherwise. Never raw internal error text.
+    player_message = _action_failure_player_message(result)
 
     message_id = _ordinary_action_failure_message_id(
         response, action, conversation_history
@@ -3191,7 +3207,7 @@ def _handle_ordinary_action_failure(
         conversation_history.append(
             {
                 "role": "system",
-                "content": SAFE_ACTION_FAILURE_MESSAGE,
+                "content": player_message,
                 "message_id": message_id,
             }
         )
@@ -3200,7 +3216,7 @@ def _handle_ordinary_action_failure(
     emit_player_output(
         {
             "type": "error",
-            "content": SAFE_ACTION_FAILURE_MESSAGE,
+            "content": player_message,
             "message_id": message_id,
         }
     )
@@ -5088,6 +5104,20 @@ def main_game_loop():
     if not os.path.exists("debug/logs/prompt_validation.json"):
         with open("debug/logs/prompt_validation.json", "w") as f:
             f.write("[]")  # Initialize with empty array
+
+    # Issue #167 / E2E gate 2d: hydrate missing live module files from their _BU
+    # masters on EVERY boot, not just new-game setup. The web entry runs this loop
+    # directly (web_interface.py:run_game_loop), and its existing-party path
+    # (startup_required() == False) otherwise never hydrates -- so an existing
+    # party that lost an area file (or a game copied without runtime files) booted
+    # into missing state that cached narration masked. main()/the wizard already
+    # call this on their paths; doing it here covers the web existing-party boot
+    # too. Idempotent (only-if-missing), guarded (never overwrites live files).
+    try:
+        from utils.startup_wizard import initialize_game_files_from_bu
+        initialize_game_files_from_bu()
+    except Exception as e:
+        debug(f"Startup module hydration skipped (non-fatal): {e}", category="startup")
 
     # Initialize companion memories from journal if needed
     try:

--- a/web/shared_state.py
+++ b/web/shared_state.py
@@ -17,6 +17,19 @@ SAFE_ACTION_FAILURE_MESSAGE = (
     "that response were applied."
 )
 
+# E2E gates 2e / W3: when a module operation is refused because the module
+# lifecycle needs recovery (a leftover build transaction, or a stray file such
+# as desktop.ini under modules/.module_transactions), the player deserves an
+# actionable reason instead of the fully-generic message above. This is a
+# CURATED, player-safe string selected by the whitelisted `recovery_required`
+# flag -- it never carries raw internal/provider error text.
+MODULE_RECOVERY_FAILURE_MESSAGE = (
+    "That action could not be completed: the module system needs to finish "
+    "recovering from a previous interrupted build. No changes were made. "
+    "Restart the game to let recovery run; if it persists, clear leftover "
+    "files under modules/.module_transactions (they are safe to remove)."
+)
+
 _player_output_sink = None
 _player_output_sink_lock = threading.RLock()
 

--- a/web/web_interface.py
+++ b/web/web_interface.py
@@ -481,6 +481,22 @@ def emit_compression_event(event_type, data):
 
 set_compression_callback(emit_compression_event)
 
+def _is_operational_diagnostic(clean_line):
+    """E2E gate 2a: operational diagnostics that must reach the Debug tab, not be
+    swallowed as DM narration. The DM-section terminators only recognize UPPERCASE
+    'DEBUG:/ERROR:/WARNING:'; recovery/scan/quarantine lines use bracket tags or
+    mixed-case 'Error:'/'Warning:' and were being appended to the narration buffer
+    (web/web_interface.py). Matched by line PREFIX so it never trips on the same
+    words inside real DM prose."""
+    if not isinstance(clean_line, str):
+        return False
+    stripped = clean_line.lstrip()
+    if stripped.startswith(('[LIFECYCLE]', '[MODULES]', '[STARTUP]')):
+        return True
+    low = stripped[:8].lower()
+    return low.startswith(('error:', 'warning:'))
+
+
 class WebOutputCapture:
     """Captures output and routes it to appropriate queues"""
     def __init__(self, queue, original_stream, is_error=False):
@@ -650,9 +666,12 @@ class WebOutputCapture:
                             self.in_dm_section = False
                             self.dm_buffer = []
                     elif any(marker in clean_line for marker in ['DEBUG:', 'ERROR:', 'WARNING:']) or \
+                         _is_operational_diagnostic(clean_line) or \
                          clean_line.startswith('[') and ('HP:' in clean_line or 'XP:' in clean_line) or \
                          clean_line.startswith('>'):
                         # This ends the DM section - send accumulated DM content as single message
+                        # (issue #167 / E2E 2a: operational diagnostics now terminate the DM
+                        # section and route to debug instead of being swallowed as narration.)
                         self._flush_dm_buffer()
                         # Send this line to debug
                         try:

--- a/web/web_interface.py
+++ b/web/web_interface.py
@@ -484,17 +484,15 @@ set_compression_callback(emit_compression_event)
 def _is_operational_diagnostic(clean_line):
     """E2E gate 2a: operational diagnostics that must reach the Debug tab, not be
     swallowed as DM narration. The DM-section terminators only recognize UPPERCASE
-    'DEBUG:/ERROR:/WARNING:'; recovery/scan/quarantine lines use bracket tags or
-    mixed-case 'Error:'/'Warning:' and were being appended to the narration buffer
-    (web/web_interface.py). Matched by line PREFIX so it never trips on the same
-    words inside real DM prose."""
+    'DEBUG:/ERROR:/WARNING:'; recovery/quarantine/module lines carry an UNAMBIGUOUS
+    bracket tag and were being appended to the narration buffer. We match ONLY those
+    reserved bracket tags (by line prefix) -- deliberately NOT bare 'Error:'/'Warning:'
+    words, which in-fiction DM prose could legitimately start a wrapped line with
+    (a read-aloud sign/note), which would truncate narration. Engine diagnostics
+    that must surface use one of these tags."""
     if not isinstance(clean_line, str):
         return False
-    stripped = clean_line.lstrip()
-    if stripped.startswith(('[LIFECYCLE]', '[MODULES]', '[STARTUP]')):
-        return True
-    low = stripped[:8].lower()
-    return low.startswith(('error:', 'warning:'))
+    return clean_line.lstrip().startswith(('[LIFECYCLE]', '[MODULES]', '[STARTUP]'))
 
 
 class WebOutputCapture:


### PR DESCRIPTION
Three of the four defects from the native-Windows fresh-install browser E2E (PR #172). P0 of the owner-approved P0+P1 plan (P1 = surgical strip of the lifecycle machinery follows separately).

## Fixes
- **2d (real bug, WSL-reproduced both ways):** deleted/missing live module area files did not rehydrate for an EXISTING party. `initialize_game_files_from_bu()` ran unconditionally only in `main()` (terminal); the web boot enters `main_game_loop()` directly, whose existing-party branch (`startup_required()==False`) never hydrated. Fix: hydrate unconditionally at the top of `main_game_loop()` (idempotent, only-if-missing). Proven: existing-party boot restores all deleted area files; a separately-modified live file stays byte-identical (never overwrites).
- **2a:** `[LIFECYCLE]`/`[MODULES]`/scan diagnostics were swallowed as DM narration (the DM-section terminator only recognized UPPERCASE `DEBUG:/ERROR:/WARNING:`), so they never reached the browser Debug tab. Fix: a prefix-precise `_is_operational_diagnostic()` terminates the DM section and routes them to `debug_output_queue` — matched by PREFIX so it never trips on the same words inside real DM prose.
- **2e/W3:** an in-game `createNewModule` refused for lifecycle recovery showed only the generic `SAFE_ACTION_FAILURE_MESSAGE`. Fix: a curated, player-safe `MODULE_RECOVERY_FAILURE_MESSAGE` (names `modules/.module_transactions` + restart hint), selected purely by the already-whitelisted `recovery_required` boolean — never raw internal text, so the sanitizer doctrine holds.

Cosmetic **1a** (player-portrait 404, pre-party plot poll) is pre-existing and intentionally untouched.

## Evidence
Unit-verified: 2a predicate routes diagnostics / ignores DM prose; 2e selects the specific message only on `recovery_required`. WSL re-ran the 2d repro against the fix: existing-party boot rehydrates all 5 deleted Keep files, Thornwood control byte-identical. Suites at the pre-existing 72/15 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)