### PR TITLE
fix(startup): #179 - reactively recover strict local templates at startup (LM Studio)

### DIFF
--- a/utils/startup_wizard.py
+++ b/utils/startup_wizard.py
@@ -1585,6 +1585,58 @@ def initialize_startup_conversation():
     safe_write_json(STARTUP_CONVERSATION_FILE, conversation)
     return conversation
 
+def _ensure_local_provider_alternation(messages, provider):
+    """Make a startup message array safe for strict-alternation local templates.
+
+    Issue #179 (same class as #168/#170). The startup wizard steers the DM
+    entirely with ``system``-role messages and calls the model with no user turn
+    (module/character selection greetings, the JSON-retry interview steps), so on
+    a fresh install with a strict local chat template the game hangs at start.
+    Validated directly against the real LM Studio server: qwen3.5-9b enforces TWO
+    constraints its Jinja template raises 500 on --
+
+      1. "No user query found in messages"  -> the array must end on a user turn.
+      2. "System message must be at the beginning" -> only ONE system message,
+         at the start (a second/mid/trailing system message is rejected).
+
+    This is applied REACTIVELY by get_ai_response -- only after a local-provider
+    call fails -- so lenient models (e.g. Gemma 12B), which accept the raw shape
+    and succeed on the first attempt, are never reshaped (byte-identical). Only a
+    strict template that actually 500s triggers a normalized retry.
+
+    For the local provider ONLY: keep the FIRST message's system as the single
+    leading system block, and convert every OTHER system message to a user turn
+    IN PLACE -- preserving its content and position. This is critical for the
+    JSON-retry interview step, whose directive ("return corrected JSON: <error>")
+    is a trailing system message that must stay the model's operative latest
+    instruction: merging it to the front and appending a generic nudge made the
+    model answer the nudge (prose) instead of emitting the corrected JSON.
+    Finally, ensure the array ends on a user turn.
+
+    An already-valid request (one leading system, turns ending on user) is
+    reconstructed identically, so this cannot alter a currently-working call.
+    OpenAI/Gemini/legacy are returned unchanged -- they accept the raw shape.
+    STARTUP-ONLY (utils/startup_wizard.get_ai_response); the main game loop and
+    every non-LM-Studio provider are untouched.
+    """
+    if provider != "lmstudio":
+        return messages
+    normalized = []
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content", "")
+        if role == "system" and not normalized:
+            normalized.append({"role": "system", "content": content})
+        elif role == "system":
+            normalized.append({"role": "user", "content": content})
+        else:
+            normalized.append({"role": role, "content": content})
+    if not normalized or normalized[-1].get("role") != "user":
+        normalized.append(
+            {"role": "user", "content": "Please respond based on the instructions above."}
+        )
+    return normalized
+
 def get_ai_response(conversation, response_format=None):
     """Return one persisted assistant turn, retrying provider failures safely.
 
@@ -1629,6 +1681,19 @@ def get_ai_response(conversation, response_format=None):
                     f"(attempt {attempt}/{STARTUP_AI_MAX_ATTEMPTS}): {exc}",
                     category="startup",
                 )
+                # Issue #179 (REACTIVE recovery): strict-alternation local
+                # templates (e.g. qwen via LM Studio) reject the wizard's
+                # system-only / trailing-system messages with a 500. After a
+                # local-provider failure, retry the remaining attempts with the
+                # alternation-normalized shape. Lenient models (e.g. Gemma) succeed
+                # on the first attempt and never reach here, so their successful
+                # requests are byte-identical -- no proactive reshape.
+                if MODEL_PROVIDER == "lmstudio":
+                    normalized = _ensure_local_provider_alternation(
+                        request_messages, MODEL_PROVIDER
+                    )
+                    if normalized != request_messages:
+                        request_messages = normalized
 
         if content is None:
             raise StartupAIResponseError(


### PR DESCRIPTION
## What & why

On a fresh install, the startup wizard steers the DM entirely with `system`-role messages and calls the model with no user turn (module/character-selection greetings; the JSON-retry interview step appends a trailing `system` directive). **Strict** local chat templates (LM Studio serving qwen3.5-9b — the model in issue #179) reject that shape with an HTTP 500 ("No user query found in messages"; "System message must be at the beginning"), hanging the game at startup. **Lenient** models (Gemma 12B — what current users run) accept the raw shape, so #179 does not reproduce on Gemma.

## Reactive design (no-op for lenient models)

Because both current users run Gemma, the fix is **reactive** so it is a complete no-op on the happy path:
- `get_ai_response` sends the **raw** messages first — byte-identical to before this change.
- **Only after a local-provider failure** does it normalize the messages and retry the remaining attempts (`STARTUP_AI_MAX_ATTEMPTS = 3`).
- Gemma succeeds on the first attempt → **never reshaped**. A strict template that actually 500s gets the normalized retry and starts.

The normalization (`_ensure_local_provider_alternation`, local provider only): keep the first message's system as the single leading system block, convert every **other** system message to a user turn **in place** (preserving content + position so the trailing JSON-retry directive stays the model's operative latest instruction), and ensure the array ends on a user turn.

This supersedes an earlier proactive version on the branch that reshaped every request and regressed Gemma (buried the retry directive → prose instead of corrected JSON). The reactive design removes all Gemma-side reshaping.

## Validation

- **Real-model A/B (live LM Studio server):** the normalized shape returns 200 on qwen3.5-9b where the raw shape 500s; on Gemma the raw shape already returns 200 and the interview retry returns corrected JSON.
- **Independent code review:** clean — all invariants hold (Gemma happy path never reshaped; reactive retry correct/idempotent/guarded; convert-in-place preserves the retry directive as the last turn; `response_format`/JSON mode untouched; no-op for non-lmstudio; edge cases don't raise; ASCII/whitespace clean; scope limited).
- **Native-Windows Gemma acceptance (round 2):** two real schema retries returned corrected JSON (not prose); character + party files created and verified; startup reached Game Running; three real gameplay turns; all startup requests remained raw/unreshaped; 14 tests; diff-check clean.

Scope: diff limited to `utils/startup_wizard.py`; the main game loop and non-LM-Studio providers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)