### PR TITLE
fix(party): keep weatherConditions (and every required key) across travel

### DIFF
--- a/core/managers/location_manager.py
+++ b/core/managers/location_manager.py
@@ -249,7 +249,12 @@ def update_world_conditions(
     )
 
     if location_info:
-        return {
+        # Start from the current block so every schema-required key survives
+        # a move. Rebuilding from scratch here dropped weatherConditions (and
+        # any field added later) after the first travel, so the product-
+        # written tracker failed party_schema validation (#271).
+        updated = dict(current_conditions)
+        updated.update({
             "year": current_conditions["year"],
             "month": current_conditions["month"],
             "day": current_conditions["day"],
@@ -265,8 +270,12 @@ def update_world_conditions(
             "majorEventsUnderway": current_conditions["majorEventsUnderway"],
             "politicalClimate": "",
             "activeEncounter": "",
-            "activeCombatEncounter": current_conditions.get("activeCombatEncounter", "")
-        }
+            "activeCombatEncounter": current_conditions.get("activeCombatEncounter", ""),
+            "weatherConditions": location_info.get(
+                "weatherConditions", current_conditions.get("weatherConditions", "")
+            ),
+        })
+        return updated
     else:
         return current_conditions
 

--- a/utils/startup_wizard.py
+++ b/utils/startup_wizard.py
@@ -1570,7 +1570,10 @@ def update_party_tracker(module_name, character_name):
                 "majorEventsUnderway": [],
                 "politicalClimate": starting_location.get("politicalClimate", ""),
                 "activeEncounter": "",
-                "activeCombatEncounter": ""
+                "activeCombatEncounter": "",
+                # Required by party_schema.json; the location's own detail
+                # text when it has one (#271).
+                "weatherConditions": starting_location.get("weatherConditions", ""),
             }
         
         # DEPRECATED: activeQuests is no longer used - module_plot.json is the single source of truth for quest data


### PR DESCRIPTION
## Summary
`update_world_conditions` rebuilt `worldConditions` from scratch on every move and never wrote `weatherConditions`; the startup wizard never seeded it either. After the first travel the product-written tracker failed `party_schema.json`.

- `update_world_conditions` now starts from the current block and overlays the move, setting `weatherConditions` from the destination (or keeping the current value). No schema-required or future key is lost.
- Startup wizard seeds `weatherConditions` from the starting location.

Closes #271.

## Verification
Called `update_world_conditions` with a schema-complete block plus an extra key against a destination with `weatherConditions: "fog"`: every required key present, `weatherConditions == "fog"`, the extra key preserved, location updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbeXaJV1MyHQbMVBDx73rK