### PR TITLE
fix(npc-builder): treat placeholder level/class/race like empty instead of crashing

### DIFF
--- a/core/generators/npc_builder.py
+++ b/core/generators/npc_builder.py
@@ -363,6 +363,18 @@ def main():
                              "NPC creation if no explicit level is given.")
     args = parser.parse_args()
 
+    # The DM pipeline passes literal placeholders when a value is not
+    # established in play ('unknown', 'none', 'n/a', ...). Treat every such
+    # placeholder exactly like empty: the builder infers a sensible default.
+    # Rejecting them crashed party recruitment mid-turn (Scout Kira, live).
+    _UNSPECIFIED = {"unknown", "none", "n/a", "na", "null", "tbd", "?"}
+    if args.level is not None and args.level.strip().lower() in _UNSPECIFIED:
+        args.level = ""
+    if args.npc_class is not None and args.npc_class.strip().lower() in _UNSPECIFIED:
+        args.npc_class = ""
+    if args.race is not None and args.race.strip().lower() in _UNSPECIFIED:
+        args.race = ""
+
     npc_name_arg = args.npc_name
     npc_race_arg = args.race
     npc_class_arg = args.npc_class


### PR DESCRIPTION
## Problem
The DM pipeline invokes `npc_builder` with literal placeholders (`unknown`, `none`, `n/a`, ...) for level, class, or race when those are not yet established in play. The builder rejected them and crashed with `Level must be an integer or empty`.

Live evidence (from the original fix): recruiting Scout Kira crashed twice, leaving the narrated companion permanently out of `party_tracker`.

## Fix
`core/generators/npc_builder.py`: normalize those placeholders to empty before capture, so the builder falls back to its own sensible-default inference exactly as it does for omitted arguments. 12-line addition, one file, no deletions, ASCII-clean.

## Validation
This exact change has been running in the hosted deployment: it passed the hosted CI suite and game-image build (hygiene, game-image-build, world-start-integration) and is live on all worlds. It builds and imports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbeXaJV1MyHQbMVBDx73rK